### PR TITLE
Add whitelists for required symbols

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -37,6 +37,12 @@ fn main() {
         // Tell bindgen to regenerate bindings if the wrapper.h's contents or transitively
         // included files change.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .whitelist_function(".+_jit")
+        .whitelist_function("_?jit_.*")
+        .whitelist_type("_?jit_.*")
+        .whitelist_var("_?jit_.*")
+        .whitelist_function("lgsys_.*")
+        .whitelist_var("lgsys_.*")
         .rustfmt_bindings(true)
         .clang_arg(format!("-I{}", incdir.to_str().unwrap()))
         .generate()


### PR DESCRIPTION
Prior to this whitelisting, `bindgen` was creating bindings for entities included by `lightning.h`, which resulted in generating a huge bindings file and lots of tests for things that are not JIT-related at all. Using a whitelist reduces this chaff.

Introducing a whitelist does require the symbol patterns to be broad enough to cover all required symbols. I expanded the patterns until compilation succeeded and the test suite passed, but if there are known functions from GNU Lightning that are not required for compilation to succeed, then this may not be a strong enough criterion.

The following script demonstrates the number of lines of code removed from the generated `bindings.rs` file (roughly proportional to the number of symbols removed).
```
cargo clean
git checkout $(git merge-base whitelisting upstream/master)
cargo build && find target/ -name bindings.rs -exec wc -l {} +
cargo clean
git checkout whitelisting
cargo build && find target/ -name bindings.rs -exec wc -l {} +
```
show this difference on my machine:
```
   13782 target//debug/build/lightning-sys-298816d890170a19/out/bindings.rs
    1339 target//debug/build/lightning-sys-298816d890170a19/out/bindings.rs
```

Similarly, the number of `bindgen`-generated tests drops to one:
```
git checkout $(git merge-base whitelisting upstream/master)
cargo test --quiet bindgen
git checkout whitelisting
cargo test --lib bindgen
```
shows this result (with some elisions):
```
# before
running 71 tests
.......................................................................
test result: ok. 71 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out
# after
running 1 test
test bindings::bindgen_test_layout_jit_cpu_t ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out
```

All the other tests were testing features of system `#include` files, but not in a way relevant to the generated bindings.