### PR TITLE
allowed multiple instances of JIT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - rust: nightly
 
 script:
-  - cargo test --verbose -- --test-threads=1
+  - cargo test --verbose
 
 notifications:
   email: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/lightning-sys"
 mashup = "0.1"
 num-traits = "0.1"
 libc = "0.2"
+lazy_static = "1.4.0"
 
 [build-dependencies]
 bindgen = "0.53"

--- a/README.md
+++ b/README.md
@@ -159,7 +159,3 @@ fn main() {
     println!("factorial({}) = {}", 5, factorial(5));
 }
 ```
-
-## known issues:
-
-- tests must be run like `cargo test -- --test-threads=1`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,9 @@ mod bindings;
 extern crate mashup;
 extern crate num_traits;
 
+#[macro_use]
+extern crate lazy_static;
+
 pub mod jit;
 pub use jit::Jit;
 


### PR DESCRIPTION
The previous implementation of `Jit` didn't allow there to be more than one instance at a time.

I fixed this by reference counting all instances and only destroying the `Jit` when no more exist.

this also means that `cargo test` works on it's own now without `-- --test-threads=1`

closes #12.
