### PR TITLE
Test builds on multiple major architectures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: rust
 
+arch:
+  - amd64
+  - arm64
+  - s390x
+  - ppc64le
+
 rust:
   - nightly
   - beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: rust
 
+dist: bionic
+
 arch:
   - amd64
   - arm64


### PR DESCRIPTION
One of the great advantages of GNU Lightning is its robust portability across operating systems and CPU architectures. Since Travis-CI supports (in alpha) [building on multiple architectures](https://docs.travis-ci.com/user/multi-cpu-architectures/), I suggest that we introduce builds on all four architectures currently supported on Travis (amd64, arm64, [s390x](https://en.wikipedia.org/wiki/Linux_on_IBM_Z), [ppc64le](https://en.wikipedia.org/wiki/Ppc64)).

Doing so will:
1. better demonstrate that `lightning-sys` aims to provides a high level of portability like the wrappered Lightning library, and
1. reduce the risk of introducing (likely via `unsafe` code) a platform dependency in the future.

The main drawback to introducing this pull request is the large number of additional Travis jobs it creates by default. If this becomes a problem, it could become reasonable to restrict the build matrix to avoid creating sixteen jobs.

This pull request specifies the Bionic Beaver (Ubuntu 18.04.4 LTS) distribution, as opposed to Xenial Xerus (Ubuntu 16.04.6), which was the default. This change could be made in a separate pull request, but in any case, it appears it must be done if s390x is to be supported, because [there is a problem](https://travis-ci.org/github/kulp/lightning-sys/jobs/685163456) getting Rust installed on Xenial on that architecture.

Build success:
- [amd64](https://travis-ci.com/github/Petelliott/lightning-sys/jobs/331073167)
- [arm64](https://travis-ci.com/github/Petelliott/lightning-sys/jobs/331073170)
- [s390x](https://travis-ci.com/github/Petelliott/lightning-sys/jobs/331073173)
- [ppc64el](https://travis-ci.com/github/Petelliott/lightning-sys/jobs/331073176)

This PR revealed #16, which must be merged before the s390x and ppc64el builds will work.