### PR TITLE
Correct a register reference in Fibonacci example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@
 //!                 js.pushargr(Reg::V(2));
 //!     let call2 = js.finishi(NULL);
 //!                 js.patch_at(&call2, &label);
-//!                 js.retval(Reg::R(1));
+//!                 js.retval(Reg::R(0));
 //!                 js.addr(Reg::R(0), Reg::R(0), Reg::V(1));
 //!
 //!                 js.patch(&refr);


### PR DESCRIPTION
During the transcription of the [GNU Lightning Fibonacci example][1] into `lightning-sys`'s doctests, `R1` was used as the return register instead of `R0`. This is likely the cause for test failures on some architectures (see #15).

[1]: https://www.gnu.org/software/lightning/manual/lightning.html#Fibonacci