### PR TITLE
Introduce macOS build with stable Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: rust
 
+os: linux
+
 dist: bionic
 
 arch:
@@ -18,6 +20,8 @@ jobs:
       arch: s390x
     - rust: stable
       arch: ppc64le
+    - rust: stable
+      os: osx
 
   allow_failures:
     - rust: nightly


### PR DESCRIPTION
In the vein of #15 demonstrating multi-architecture support, the current PR begins to demonstrate multi-OS support. In the long run, it would be nice to demonstrate [Windows](https://docs.travis-ci.com/user/reference/windows/) in particular, using [MSYS2](https://docs.travis-ci.com/user/reference/windows/#how-do-i-use-msys2) to provide a MinGW build environment, but in the short term, we can at least enable a macOS build.