### PR TITLE
Update GNU Lightning release to 2.1.3

### DIFF
--- a/release
+++ b/release
@@ -1,1 +1,1 @@
-lightning-2.1.2
+lightning-2.1.3


### PR DESCRIPTION
[GNU Lightning 2.1.3 was tagged on 18 Sep 2019](http://git.savannah.gnu.org/cgit/lightning.git/commit/?h=lightning-2.1.3&id=e0383cb2de8eeaa30f86ae6c586740e8e93abbf6). Let us use this newest version.