### PR TITLE
Switch back to static linking for liblightning

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -55,7 +55,7 @@ fn main() {
 
     println!("cargo:rustc-link-search=native={}", libdir.to_str().unwrap());
 
-    println!("cargo:rustc-link-lib=dylib=lightning");
+    println!("cargo:rustc-link-lib=static=lightning");
 
     let bindings = bindgen::Builder::default()
         .header("wrapper.h")


### PR DESCRIPTION
Fixes #22.

It is not clear what changed to make this reversion so easy. I specifically checked on macOS and Linux whether undoing #19 would make a linking problem reappear, but I failed to reproduce any issues. If Travis builds can succeed, then this will appear to be a non-issue now.