### PR TITLE
Introduce coverage reporting with Tarpaulin

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,17 @@
+name: Coverage
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  coverage:
+    runs-on: [ ubuntu-latest ]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run cargo-tarpaulin
+      uses: actions-rs/tarpaulin@v0.1.0
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -114,4 +114,133 @@ mod tests {
         Reg::F(jit.f_num()-1).to_ffi();
         Reg::F(0).to_ffi();
     }
+
+    #[test]
+    fn test_printf() {
+        use std::ffi::CString;
+        use crate::{Jit, JitWord, Reg, JitPointer};
+        use std::convert::TryInto;
+
+        let jit = Jit::new();
+        let js = jit.new_state();
+
+        // make sure this outlives any calls
+        let cs = CString::new("generated %d bytes\n").unwrap();
+
+        let start = js.note(file!(), line!());
+        js.prolog();
+        let inarg = js.arg();
+        js.getarg(Reg::R(1), &inarg);
+        js.prepare();
+        js.pushargi(cs.as_ptr() as JitWord);
+        js.ellipsis();
+        js.pushargr(Reg::R(1));
+        js.finishi(libc::printf as JitPointer);
+        js.ret();
+        js.epilog();
+        let end = js.note(file!(), line!());
+
+        let my_function = unsafe{ js.emit::<extern fn(JitWord)>() };
+        /* call the generated code, passing its size as argument */
+        my_function((js.address(&end) as u64 - js.address(&start) as u64).try_into().unwrap());
+        js.clear();
+
+        // TODO: dissasembly has not been implemented yet
+        // js.dissasemble();
+    }
+
+    #[test]
+    fn test_fibonacci() {
+        use crate::{Jit, JitWord, Reg, JitPointer, NULL};
+
+        let jit = Jit::new();
+        let js = jit.new_state();
+
+        let label = js.label();
+                    js.prolog();
+        let inarg = js.arg();
+                    js.getarg(Reg::R(0), &inarg);
+        let zero  = js.beqi(Reg::R(0), 0);
+                    js.movr(Reg::V(0), Reg::R(0));
+                    js.movi(Reg::R(0), 1);
+        let refr  = js.blei(Reg::V(0), 2);
+                    js.subi(Reg::V(1), Reg::V(0), 1);
+                    js.subi(Reg::V(2), Reg::V(0), 2);
+                    js.prepare();
+                    js.pushargr(Reg::V(1));
+        let call  = js.finishi(NULL);
+                    js.patch_at(&call, &label);
+                    js.retval(Reg::V(1));
+                    js.prepare();
+                    js.pushargr(Reg::V(2));
+        let call2 = js.finishi(NULL);
+                    js.patch_at(&call2, &label);
+                    js.retval(Reg::R(0));
+                    js.addr(Reg::R(0), Reg::R(0), Reg::V(1));
+
+                    js.patch(&refr);
+                    js.patch(&zero);
+                    js.retr(Reg::R(0));
+                    js.epilog();
+
+        let fib = unsafe{ js.emit::<extern fn(JitWord) -> JitWord>() };
+        js.clear();
+
+        println!("fib({})={}", 32, fib(32));
+        assert_eq!(0, fib(0));
+        assert_eq!(1, fib(1));
+        assert_eq!(1, fib(2));
+        assert_eq!(2178309, fib(32));
+    }
+
+    #[test]
+    fn test_factorial() {
+        use crate::{Jit, JitWord, Reg, NULL};
+
+        let jit = Jit::new();
+        let js = jit.new_state();
+
+        let fact = js.forward();
+
+                    js.prolog();
+        let inarg = js.arg();
+                    js.getarg(Reg::R(0), &inarg);
+                    js.prepare();
+                    js.pushargi(1);
+                    js.pushargr(Reg::R(0));
+        let call  = js.finishi(NULL);
+                    js.patch_at(&call, &fact);
+
+                    js.retval(Reg::R(0));
+                    js.retr(Reg::R(0));
+                    js.epilog();
+
+        js.link(&fact);
+                    js.prolog();
+                    js.frame(16);
+        let f_ent = js.label(); // TCO entry point
+        let ac    = js.arg();
+        let ina   = js.arg();
+                    js.getarg(Reg::R(0), &ac);
+                    js.getarg(Reg::R(1), &ina);
+        let f_out = js.blei(Reg::R(1), 1);
+                    js.mulr(Reg::R(0), Reg::R(0), Reg::R(1));
+                    js.putargr(Reg::R(0), &ac);
+                    js.subi(Reg::R(1), Reg::R(1), 1);
+                    js.putargr(Reg::R(1), &ina);
+        let jump  = js.jmpi(); // tail call optimiation
+                    js.patch_at(&jump, &f_ent);
+                    js.patch(&f_out);
+                    js.retr(Reg::R(0));
+
+        let factorial = unsafe{ js.emit::<extern fn(JitWord) -> JitWord>() };
+        js.clear();
+
+        println!("factorial({}) = {}", 5, factorial(5));
+        assert_eq!(1, factorial(1));
+        assert_eq!(2, factorial(2));
+        assert_eq!(6, factorial(3));
+        assert_eq!(24, factorial(4));
+        assert_eq!(120, factorial(5));
+    }
 }


### PR DESCRIPTION
Introducing metrics for test coverage with [tarpaulin](https://github.com/xd009642/tarpaulin) is fairly easy to set up, at least on GitHub Actions, although it requires a few workarounds at present.

- Getting coverage for doctests is possible, but not working for me at present, so I had to copy doctests into their own test cases, in 9a32fadaf349086d3efe0525a16cebb4042ab4c8.
- I already knew how to set up tarpaulin on GitHub Actions, so I introduced a [new GHA Workflow](https://github.com/kulp/lightning-sys/runs/661769237) instead of adding coverage to the Travis build.

I gathered some [test coverage metrics](https://codecov.io/gh/kulp/lightning-sys/tree/coverage/src) for this PR's branch. It might be useful to look at [another example](https://github.com/kulp/tenyr/pull/42#issuecomment-626067887) of what codecov.io provides in terms of comments on PRs, which hopefully will spur improvements over time.

I will keep this PR in draft until we can discuss what the acceptance criteria should be for `lightning-sys`'s coverage configuration.