### PR TITLE
Address and suppress lints from Clippy

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -28,7 +28,7 @@ impl Jit {
         Jit{}
     }
 
-    pub fn new_state<'a>(&'a self) -> JitState<'a> {
+    pub fn new_state(&self) -> JitState {
         JitState {
             state: unsafe {
                 bindings::jit_new_state()

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -150,6 +150,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::print_literal)]
     fn test_fibonacci() {
         use crate::{Jit, JitWord, Reg, NULL};
 
@@ -194,6 +195,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::print_literal)]
     fn test_factorial() {
         use crate::{Jit, JitWord, Reg, NULL};
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -151,7 +151,7 @@ mod tests {
 
     #[test]
     fn test_fibonacci() {
-        use crate::{Jit, JitWord, Reg, JitPointer, NULL};
+        use crate::{Jit, JitWord, Reg, NULL};
 
         let jit = Jit::new();
         let js = jit.new_state();

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::mutex_atomic)] // Avoid clippy warning about JITS_MADE
+#![allow(clippy::new_without_default)] // Avoid clippy warning about Jit::new
 
 use std::os::raw;
 use std::ptr;

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -190,7 +190,7 @@ mod tests {
         assert_eq!(0, fib(0));
         assert_eq!(1, fib(1));
         assert_eq!(1, fib(2));
-        assert_eq!(2178309, fib(32));
+        assert_eq!(2_178_309, fib(32));
     }
 
     #[test]

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::mutex_atomic)] // Avoid clippy warning about JITS_MADE
+
 use std::os::raw;
 use std::ptr;
 use std::sync::Mutex;

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -189,9 +189,7 @@ impl<'a> JitState<'a> {
     // there is no way to require a function type in a trait bound
     // without specifying the number of arguments
     pub unsafe fn emit<T: Copy>(&self) -> T {
-        *std::mem::transmute::<&JitPointer, &T>(
-            &bindings::_jit_emit(self.state)
-        )
+        *(&bindings::_jit_emit(self.state) as *const *mut core::ffi::c_void as *const T)
     }
 
     pub fn raw_emit(&self) -> JitPointer {

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -178,6 +178,7 @@ macro_rules! jit_alias {
 }
 
 /// `JitState` utility methods
+#[allow(clippy::needless_lifetimes)] // TODO
 impl<'a> JitState<'a> {
     pub fn clear(&self) {
         unsafe {
@@ -216,6 +217,7 @@ impl<'a> JitState<'a> {
 }
 
 /// implmentations of general instructions
+#[allow(clippy::needless_lifetimes)] // TODO
 impl<'a> JitState<'a> {
     jit_impl!(live, w);
     jit_impl!(align, w);
@@ -535,6 +537,7 @@ impl<'a> JitState<'a> {
 }
 
 /// implmentations of 32-bit float instructions
+#[allow(clippy::needless_lifetimes)] // TODO
 impl<'a> JitState<'a> {
     jit_reexport!(arg_f; -> JitNode);
     jit_reexport!(getarg_f, reg: Reg, arg: &JitNode);
@@ -641,6 +644,7 @@ impl<'a> JitState<'a> {
 }
 
 /// implmentations of 64-bit float instructions
+#[allow(clippy::needless_lifetimes)] // TODO
 impl<'a> JitState<'a> {
     jit_reexport!(arg_d; -> JitNode);
     jit_reexport!(getarg_d, reg: Reg, arg: &JitNode);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,7 @@
 //!     assert_eq!(120, factorial(5));
 //! }
 //! ```
+// Suppress some lints for bindings specifically.
 #[allow(non_upper_case_globals)]
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
@@ -167,6 +168,7 @@
 #[allow(clippy::unreadable_literal)]
 #[allow(clippy::trivially_copy_pass_by_ref)]
 #[allow(clippy::useless_transmute)]
+#[allow(clippy::too_many_arguments)]
 mod bindings;
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,9 @@
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[allow(improper_ctypes)] // TODO
+#[allow(clippy::unreadable_literal)]
+#[allow(clippy::trivially_copy_pass_by_ref)]
+#[allow(clippy::useless_transmute)]
 mod bindings;
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,7 @@
 // Enforce some lints for the whole crate.
 #![deny(clippy::needless_lifetimes)]
 #![deny(clippy::transmute_ptr_to_ptr)]
+#![allow(clippy::needless_doctest_main)] // remain faithful to original examples
 
 // Suppress some lints for bindings specifically.
 #[allow(non_upper_case_globals)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,9 @@
 //!     assert_eq!(120, factorial(5));
 //! }
 //! ```
+// Enforce some lints for the whole crate.
+#![deny(clippy::needless_lifetimes)]
+
 // Suppress some lints for bindings specifically.
 #[allow(non_upper_case_globals)]
 #[allow(non_camel_case_types)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,9 +167,7 @@
 // Suppress some lints for bindings specifically.
 #[allow(non_upper_case_globals)]
 #[allow(non_camel_case_types)]
-#[allow(non_snake_case)]
 #[allow(dead_code)]
-#[allow(improper_ctypes)] // TODO
 #[allow(clippy::unreadable_literal)]
 #[allow(clippy::trivially_copy_pass_by_ref)]
 #[allow(clippy::useless_transmute)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,7 @@
 //! ```
 // Enforce some lints for the whole crate.
 #![deny(clippy::needless_lifetimes)]
+#![deny(clippy::transmute_ptr_to_ptr)]
 
 // Suppress some lints for bindings specifically.
 #[allow(non_upper_case_globals)]


### PR DESCRIPTION
This PR mostly addresses lints from [Clippy](https://github.com/rust-lang/rust-clippy). Some lints are explicitly marked `deny` so that they will not be silently reintroduced. This is a matter of style and could be subject to debate.