### PR TITLE
Replace mashup with paste

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/petelliott/lightning-sys"
 documentation = "https://docs.rs/lightning-sys"
 
 [dependencies]
-mashup = "0.1"
 paste = "0.1"
 lazy_static = "1.4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/lightning-sys"
 
 [dependencies]
 mashup = "0.1"
+paste = "0.1"
 lazy_static = "1.4.0"
 
 [build-dependencies]

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -90,34 +90,29 @@ macro_rules! jit_impl_inner {
     };
 }
 
-macro_rules! jit_prefix {
-    ( $form:ident ) => {{
-        mashup! {
-            m["method"] = _jit_ $form;
-        }
-        m! {
-            bindings::"method"
-        }
-    }}
-}
-
 macro_rules! jit_reexport {
     ( $fn:ident $(, $arg:ident : $typ:ty )*; -> JitNode) => {
-        pub fn $fn<'b>(&'b self $(, $arg: $typ )*) -> JitNode<'b> {
-            JitNode{
-                node: unsafe { jit_prefix!($fn)(self.state $(, $arg.to_ffi())*) },
-                phantom: std::marker::PhantomData,
+        paste::item! {
+            pub fn $fn<'b>(&'b self $(, $arg: $typ )*) -> JitNode<'b> {
+                JitNode{
+                    node: unsafe { bindings::[< _jit_ $fn >](self.state $(, $arg.to_ffi())*) },
+                    phantom: std::marker::PhantomData,
+                }
             }
         }
     };
     ( $fn:ident $(, $arg:ident : $typ:ty )*; -> bool) => {
-        pub fn $fn<'b>(&'b self $(, $arg: $typ )*) -> bool {
-            unsafe { jit_prefix!($fn)(self.state $(, $arg.to_ffi())*) != 0 }
+        paste::item! {
+            pub fn $fn<'b>(&'b self $(, $arg: $typ )*) -> bool {
+                unsafe { bindings::[< _jit_ $fn >](self.state $(, $arg.to_ffi())*) != 0 }
+            }
         }
     };
     ( $fn:ident $(, $arg:ident : $typ:ty )*; -> $ret:ty) => {
-        pub fn $fn<'b>(&'b self $(, $arg: $typ )*) -> $ret {
-            unsafe { jit_prefix!($fn)(self.state $(, $arg.to_ffi())*) }
+        paste::item! {
+            pub fn $fn<'b>(&'b self $(, $arg: $typ )*) -> $ret {
+                unsafe { bindings::[< _jit_ $fn >](self.state $(, $arg.to_ffi())*) }
+            }
         }
     };
     ( $fn:ident $(, $arg:ident : $typ:ty )*) => { jit_reexport!($fn $(, $arg : $typ)*; -> ()); }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,9 +175,6 @@
 mod bindings;
 
 #[macro_use]
-extern crate mashup;
-
-#[macro_use]
 extern crate lazy_static;
 
 pub mod jit;


### PR DESCRIPTION
The author of [mashup](https://github.com/dtolnay/mashup) suggests to use his [paste](https://github.com/dtolnay/paste) instead. I find it easier to read.