### PR TITLE
Port RPN example

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,5 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run cargo-tarpaulin
       uses: actions-rs/tarpaulin@v0.1.0
+      with:
+        args: '--run-types Tests,Examples'
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/C/lightning-sys.h
+++ b/C/lightning-sys.h
@@ -9,4 +9,5 @@ int lgsys_JIT_R_NUM(void);
 int lgsys_JIT_V_NUM(void);
 int lgsys_JIT_F_NUM(void);
 
+extern const int lgsys_JIT_FP;
 #endif

--- a/C/register.c
+++ b/C/register.c
@@ -24,3 +24,5 @@ int lgsys_JIT_V_NUM(void) {
 int lgsys_JIT_F_NUM(void) {
     return JIT_F_NUM;
 }
+
+const int lgsys_JIT_FP = JIT_FP;

--- a/examples/rpn.rs
+++ b/examples/rpn.rs
@@ -1,0 +1,96 @@
+use libc::c_int;
+
+use lightning_sys::*;
+
+use core::mem::size_of;
+
+fn stack_push(js: &mut JitState, reg: Reg, sp: &mut c_int) {
+    js.stxi_i((*sp).into(), Reg::FP, reg);
+    *sp += size_of::<c_int>() as c_int;
+}
+
+fn stack_pop(js: &mut JitState, reg: Reg, sp: &mut c_int) {
+    *sp -= size_of::<c_int>() as c_int;
+    js.ldxi_i(reg, Reg::FP, (*sp).into());
+}
+
+fn compile_rpn<'a>(js: &mut JitState<'a>, mut expr: &str) -> JitNode<'a> {
+    let func = js.note(None, 0);
+    js.prolog();
+    let inp = js.arg();
+    let stack_base = js.allocai(32 * size_of::<c_int>() as c_int);
+    let mut stack_ptr = stack_base;
+
+    js.getarg_i(Reg::R(2), &inp);
+
+    while ! expr.is_empty() {
+        if expr.starts_with(|c: char| c.is_ascii_digit()) {
+            let s: String = expr.chars().take_while(char::is_ascii_digit).collect();
+            let val = s.parse::<JitWord>().unwrap();
+            expr = &expr[s.len()..];
+            stack_push(js, Reg::R(0), &mut stack_ptr);
+            js.movi(Reg::R(0), val);
+        } else {
+            match expr.as_bytes().get(0) {
+                Some(b'x') => {
+                    stack_push(js, Reg::R(0), &mut stack_ptr);
+                    js.movr(Reg::R(0), Reg::R(2));
+                },
+                Some(b'+') => {
+                    stack_pop(js, Reg::R(1), &mut stack_ptr);
+                    js.addr(Reg::R(0), Reg::R(1), Reg::R(0));
+                },
+                Some(b'-') => {
+                    stack_pop(js, Reg::R(1), &mut stack_ptr);
+                    js.subr(Reg::R(0), Reg::R(1), Reg::R(0));
+                },
+                Some(b'*') => {
+                    stack_pop(js, Reg::R(1), &mut stack_ptr);
+                    js.mulr(Reg::R(0), Reg::R(1), Reg::R(0));
+                },
+                Some(b'/') => {
+                    stack_pop(js, Reg::R(1), &mut stack_ptr);
+                    js.divr(Reg::R(0), Reg::R(1), Reg::R(0));
+                },
+                _ => panic!("cannot compile: {}", expr),
+            }
+            expr = &expr[1..];
+        }
+    }
+    js.retr(Reg::R(0));
+    js.epilog();
+
+    return func;
+}
+
+fn main() {
+    let j = Jit::new();
+    let mut js = j.new_state();
+
+    let nc = compile_rpn(&mut js, "32x9*5/+");
+    let nf = compile_rpn(&mut js, "x32-5*9/");
+
+    let _ = js.raw_emit();
+
+    unsafe fn to_func<T,R>(ptr: JitPointer) -> extern "C" fn(T) -> R {
+        *(&ptr as *const *mut core::ffi::c_void as *const extern "C" fn(T) -> R)
+    }
+
+    let c2f = js.address(&nc);
+    let c2f = unsafe { to_func::<_, c_int>(c2f) };
+    let f2c = js.address(&nf);
+    let f2c = unsafe { to_func::<_, c_int>(f2c) };
+    js.clear();
+
+    print!("\nC:");
+    for i in 0..=10 { print!("{:3} ", i * 10); }
+    print!("\nF:");
+    for i in 0..=10 { print!("{:3} ", c2f(i * 10)); }
+    print!("\n");
+
+    print!("\nF:");
+    for i in 0..=10 { print!("{:3} ", i * 18 + 32); }
+    print!("\nC:");
+    for i in 0..=10 { print!("{:3} ", f2c(i * 18 + 32)); }
+    print!("\n");
+}

--- a/examples/rpn.rs
+++ b/examples/rpn.rs
@@ -60,7 +60,7 @@ fn compile_rpn<'a>(js: &mut JitState<'a>, mut expr: &str) -> JitNode<'a> {
     js.retr(Reg::R(0));
     js.epilog();
 
-    return func;
+    func
 }
 
 fn main() {
@@ -86,11 +86,11 @@ fn main() {
     for i in 0..=10 { print!("{:3} ", i * 10); }
     print!("\nF:");
     for i in 0..=10 { print!("{:3} ", c2f(i * 10)); }
-    print!("\n");
+    println!();
 
     print!("\nF:");
     for i in 0..=10 { print!("{:3} ", i * 18 + 32); }
     print!("\nC:");
     for i in 0..=10 { print!("{:3} ", f2c(i * 18 + 32)); }
-    print!("\n");
+    println!();
 }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -130,7 +130,7 @@ mod tests {
         // make sure this outlives any calls
         let cs = CString::new("generated %d bytes\n").unwrap();
 
-        let start = js.note(file!(), line!());
+        let start = js.note(Some(file!()), line!());
         js.prolog();
         let inarg = js.arg();
         js.getarg(Reg::R(1), &inarg);
@@ -141,7 +141,7 @@ mod tests {
         js.finishi(libc::printf as JitPointer);
         js.ret();
         js.epilog();
-        let end = js.note(file!(), line!());
+        let end = js.note(Some(file!()), line!());
 
         let my_function = unsafe{ js.emit::<extern fn(JitWord)>() };
         /* call the generated code, passing its size as argument */

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -204,11 +204,15 @@ impl<'a> JitState<'a> {
         }
     }
 
-    pub fn note<'b>(&'b self, file: &str, line: u32) -> JitNode<'b> {
+    pub fn note<'b>(&'b self, file: Option<&str>, line: u32) -> JitNode<'b> {
         // I looked at the lightning code, this will be copied
-        let cs = CString::new(file).unwrap();
+        let cs = file
+            .map(CString::new)
+            .map(Result::unwrap)
+            .map(|c| c.as_ptr())
+            .unwrap_or(core::ptr::null());
         JitNode{
-            node: unsafe { bindings::_jit_note(self.state, cs.as_ptr(), line as i32) },
+            node: unsafe { bindings::_jit_note(self.state, cs, line as i32) },
             phantom: std::marker::PhantomData,
         }
     }

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -69,6 +69,17 @@ macro_rules! jit_impl {
     ( $op:ident, i_qww ) => { jit_impl_inner!($op, qww, a: Reg => i32, b: Reg => i32, c: Reg => JitWord, d: JitWord => _); };
 }
 
+macro_rules! jit_store {
+    ( $op:ident, ww ) => { jit_impl_inner!($op, ww, a: Reg => JitWord, b: Reg => JitWord); };
+
+    ( $op:ident, i_pw ) => { jit_impl_inner!($op, pw, a: JitPointer => _, b: Reg => JitWord); };
+
+    ( $op:ident, www ) => { jit_impl_inner!($op, www, a: Reg => JitWord, b: Reg => JitWord, c: Reg => JitWord); };
+
+    ( $op:ident, i_www ) => { jit_impl_inner!($op, www, a: JitWord => _, b: Reg => JitWord, c: Reg => JitWord); };
+
+}
+
 macro_rules! jit_impl_type {
     ( $e:expr => _ ) => { $e };
     ( $e:expr => $t:ty ) => { $e as $t };
@@ -395,16 +406,16 @@ impl<'a> JitState<'a> {
     #[cfg(target_pointer_width = "64")]
     jit_alias!(ldxr_l => ldxr, targ: Reg, a: Reg, b: Reg; -> JitNode);
 
-    jit_impl!(str_c, ww);
-    jit_impl!(sti_c, i_pw);
-    jit_impl!(str_s, ww);
-    jit_impl!(sti_s, i_pw);
-    jit_impl!(str_i, ww);
-    jit_impl!(sti_i, i_pw);
+    jit_store!(str_c, ww);
+    jit_store!(sti_c, i_pw);
+    jit_store!(str_s, ww);
+    jit_store!(sti_s, i_pw);
+    jit_store!(str_i, ww);
+    jit_store!(sti_i, i_pw);
     #[cfg(target_pointer_width = "64")]
-    jit_impl!(str_l, ww);
+    jit_store!(str_l, ww);
     #[cfg(target_pointer_width = "64")]
-    jit_impl!(sti_l, i_pw);
+    jit_store!(sti_l, i_pw);
     #[cfg(target_pointer_width = "32")]
     jit_alias!(str_i => str, targ: Reg, src: Reg; -> JitNode);
     #[cfg(target_pointer_width = "32")]
@@ -414,24 +425,24 @@ impl<'a> JitState<'a> {
     #[cfg(target_pointer_width = "64")]
     jit_alias!(sti_i => sti, targ: JitPointer, src: Reg; -> JitNode);
 
-    jit_impl!(stxr_c, www);
-    jit_impl!(stxi_c, i_www);
-    jit_impl!(stxr_s, www);
-    jit_impl!(stxi_s, i_www);
-    jit_impl!(stxr_i, www);
-    jit_impl!(stxi_i, i_www);
+    jit_store!(stxr_c, www);
+    jit_store!(stxi_c, i_www);
+    jit_store!(stxr_s, www);
+    jit_store!(stxi_s, i_www);
+    jit_store!(stxr_i, www);
+    jit_store!(stxi_i, i_www);
     #[cfg(target_pointer_width = "64")]
-    jit_impl!(stxr_l, www);
+    jit_store!(stxr_l, www);
     #[cfg(target_pointer_width = "64")]
-    jit_impl!(stxi_l, i_www);
+    jit_store!(stxi_l, i_www);
     #[cfg(target_pointer_width = "32")]
-    jit_alias!(stxr_i => stxr, targ: Reg, src: Reg, off: Reg; -> JitNode);
+    jit_alias!(stxr_i => stxr, off: Reg, targ: Reg, src: Reg; -> JitNode);
     #[cfg(target_pointer_width = "32")]
-    jit_alias!(stxi_i => stxi, targ: Reg, src: Reg, off: JitWord; -> JitNode);
+    jit_alias!(stxi_i => stxi, off: JitWord, targ: Reg, src: Reg; -> JitNode);
     #[cfg(target_pointer_width = "64")]
-    jit_alias!(stxr_l => stxr, targ: Reg, src: Reg, off: Reg; -> JitNode);
+    jit_alias!(stxr_l => stxr, off: Reg, targ: Reg, src: Reg; -> JitNode);
     #[cfg(target_pointer_width = "64")]
-    jit_alias!(stxi_l => stxi, targ: Reg, src: Reg, off: JitWord; -> JitNode);
+    jit_alias!(stxi_l => stxi, off: JitWord, targ: Reg, src: Reg; -> JitNode);
 
     jit_branch!(bltr, r);
     jit_branch!(blti, i);
@@ -579,10 +590,10 @@ impl<'a> JitState<'a> {
     jit_impl!(ldxr_f, www);
     jit_impl!(ldxi_f, i_www);
 
-    jit_impl!(str_f, ww);
-    jit_impl!(sti_f, i_pw);
-    jit_impl!(stxr_f, www);
-    jit_impl!(stxi_f, i_www);
+    jit_store!(str_f, ww);
+    jit_store!(sti_f, i_pw);
+    jit_store!(stxr_f, www);
+    jit_store!(stxi_f, i_www);
 
     jit_branch!(bltr_f, r);
     jit_branch!(blti_f, f);
@@ -685,10 +696,10 @@ impl<'a> JitState<'a> {
     jit_impl!(ldxr_d, www);
     jit_impl!(ldxi_d, i_www);
 
-    jit_impl!(str_d, ww);
-    jit_impl!(sti_d, i_pw);
-    jit_impl!(stxr_d, www);
-    jit_impl!(stxi_d, i_www);
+    jit_store!(str_d, ww);
+    jit_store!(sti_d, i_pw);
+    jit_store!(stxr_d, www);
+    jit_store!(stxi_d, i_www);
 
     jit_branch!(bltr_d, r);
     jit_branch!(blti_d, d);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!     // make sure this outlives any calls
 //!     let cs = CString::new("generated %d bytes\n").unwrap();
 //!
-//!     let start = js.note(file!(), line!());
+//!     let start = js.note(Some(file!()), line!());
 //!     js.prolog();
 //!     let inarg = js.arg();
 //!     js.getarg(Reg::R(1), &inarg);
@@ -48,7 +48,7 @@
 //!     js.finishi(libc::printf as JitPointer);
 //!     js.ret();
 //!     js.epilog();
-//!     let end = js.note(file!(), line!());
+//!     let end = js.note(Some(file!()), line!());
 //!
 //!     let my_function = unsafe{ js.emit::<extern fn(JitWord)>() };
 //!     /* call the generated code, passing its size as argument */

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,6 +6,7 @@ pub enum Reg {
     R(bindings::jit_gpr_t),
     V(bindings::jit_gpr_t),
     F(bindings::jit_gpr_t),
+    FP,
 }
 
 pub struct JitNode<'a> {
@@ -48,6 +49,8 @@ impl ToFFI for Reg {
             } else {
                 panic!("register 'F{}' is not supported", i);
             },
+
+            Reg::FP => unsafe { bindings::lgsys_JIT_FP },
         }
     }
 }


### PR DESCRIPTION
The Reverse Polish Notation calculator example from the GNU Lightning sources has been ported, and bugs in this crate have been fixed along the way.

Some small but significant changes to the API (lifetimes and nullability) were made as a result of findings made during porting. In particular, I believe the lifetime constraints on almost every function were too tight -- a `JitNode` has the same lifetime as its `JitState`, not the same lifetime as a *reference* to the `JitState` (which lifetime is sometimes shorter than necessary).

Also, the operand order for store operations was corrected (the position of an immediate value is unusual compared to other instructions).

The example can be run with `cargo run --example rpn`, and produces the same output as the C version :
```

C:  0  10  20  30  40  50  60  70  80  90 100
F: 32  50  68  86 104 122 140 158 176 194 212

F: 32  50  68  86 104 122 140 158 176 194 212
C:  0  10  20  30  40  50  60  70  80  90 100
```