### PR TITLE
Make API semantically mutating

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Safe gnu lightning bindings for rust
 use lightning_sys::{Jit, Reg, JitPointer, JitWord};
 
 let jit = Jit::new();
-let js = jit.new_state();
+let mut js = jit.new_state();
 
 js.prolog();
 let inarg = js.arg();
@@ -39,7 +39,7 @@ use std::convert::TryInto;
 
 fn main() {
     let jit = Jit::new();
-    let js = jit.new_state();
+    let mut js = jit.new_state();
 
     // make sure this outlives any calls
     let cs = CString::new("generated %d bytes\n").unwrap();
@@ -73,7 +73,7 @@ use lightning_sys::{Jit, JitWord, Reg, JitPointer, NULL};
 
 fn main() {
     let jit = Jit::new();
-    let js = jit.new_state();
+    let mut js = jit.new_state();
 
     let label = js.label();
                 js.prolog();
@@ -119,7 +119,7 @@ use lightning_sys::{Jit, JitWord, Reg, NULL};
 
 fn main() {
     let jit = Jit::new();
-    let js = jit.new_state();
+    let mut js = jit.new_state();
 
     let fact = js.forward();
 

--- a/examples/rpn.rs
+++ b/examples/rpn.rs
@@ -64,7 +64,7 @@ fn compile_rpn<'a>(js: &mut JitState<'a>, mut expr: &str) -> JitNode<'a> {
 }
 
 fn main() {
-    let j = Jit::new();
+    let mut j = Jit::new();
     let mut js = j.new_state();
 
     let nc = compile_rpn(&mut js, "32x9*5/+");

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -8,9 +8,10 @@ use std::sync::Mutex;
 use crate::bindings;
 use crate::JitState;
 
+use std::marker::PhantomData;
 
 #[derive(Debug)]
-pub struct Jit<'a>(std::marker::PhantomData<&'a ()>);
+pub struct Jit<'a>(PhantomData<&'a ()>);
 
 lazy_static! {
     static ref JITS_MADE: Mutex<usize> = Mutex::new(0);
@@ -28,7 +29,7 @@ impl<'a> Jit<'a> {
         }
 
         *m += 1;
-        Jit(std::marker::PhantomData)
+        Jit(PhantomData)
     }
 
     pub fn new_state(&self) -> JitState {
@@ -36,7 +37,7 @@ impl<'a> Jit<'a> {
             state: unsafe {
                 bindings::jit_new_state()
             },
-            phantom: std::marker::PhantomData,
+            phantom: PhantomData,
         }
     }
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -10,14 +10,14 @@ use crate::JitState;
 
 
 #[derive(Debug)]
-pub struct Jit;
+pub struct Jit<'a>(std::marker::PhantomData<&'a ()>);
 
 lazy_static! {
     static ref JITS_MADE: Mutex<usize> = Mutex::new(0);
 }
 
-impl Jit {
-    pub fn new() -> Jit {
+impl<'a> Jit<'a> {
+    pub fn new() -> Jit<'a> {
         let mut m = JITS_MADE.lock().unwrap();
 
         if *m == 0 {
@@ -28,7 +28,7 @@ impl Jit {
         }
 
         *m += 1;
-        Jit{}
+        Jit(std::marker::PhantomData)
     }
 
     pub fn new_state(&self) -> JitState {
@@ -36,7 +36,7 @@ impl Jit {
             state: unsafe {
                 bindings::jit_new_state()
             },
-            jit: &self,
+            phantom: std::marker::PhantomData,
         }
     }
 
@@ -60,7 +60,7 @@ impl Jit {
 
 }
 
-impl Drop for Jit {
+impl<'a> Drop for Jit<'a> {
     fn drop(&mut self) {
         let mut m = JITS_MADE.lock().unwrap();
         *m -= 1;

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -126,7 +126,7 @@ mod tests {
         use std::convert::TryInto;
 
         let mut jit = Jit::new();
-        let js = jit.new_state();
+        let mut js = jit.new_state();
 
         // make sure this outlives any calls
         let cs = CString::new("generated %d bytes\n").unwrap();
@@ -159,7 +159,7 @@ mod tests {
         use crate::{Jit, JitWord, Reg, NULL};
 
         let mut jit = Jit::new();
-        let js = jit.new_state();
+        let mut js = jit.new_state();
 
         let label = js.label();
                     js.prolog();
@@ -204,7 +204,7 @@ mod tests {
         use crate::{Jit, JitWord, Reg, NULL};
 
         let mut jit = Jit::new();
-        let js = jit.new_state();
+        let mut js = jit.new_state();
 
         let fact = js.forward();
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -32,7 +32,7 @@ impl<'a> Jit<'a> {
         Jit(PhantomData)
     }
 
-    pub fn new_state(&self) -> JitState {
+    pub fn new_state(&mut self) -> JitState {
         JitState {
             state: unsafe {
                 bindings::jit_new_state()
@@ -125,7 +125,7 @@ mod tests {
         use crate::{Jit, JitWord, Reg, JitPointer};
         use std::convert::TryInto;
 
-        let jit = Jit::new();
+        let mut jit = Jit::new();
         let js = jit.new_state();
 
         // make sure this outlives any calls
@@ -158,7 +158,7 @@ mod tests {
     fn test_fibonacci() {
         use crate::{Jit, JitWord, Reg, NULL};
 
-        let jit = Jit::new();
+        let mut jit = Jit::new();
         let js = jit.new_state();
 
         let label = js.label();
@@ -203,7 +203,7 @@ mod tests {
     fn test_factorial() {
         use crate::{Jit, JitWord, Reg, NULL};
 
-        let jit = Jit::new();
+        let mut jit = Jit::new();
         let js = jit.new_state();
 
         let fact = js.forward();

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -1,5 +1,4 @@
 use crate::bindings;
-use crate::Jit;
 use crate::Reg;
 use crate::JitNode;
 use crate::{JitWord, JitPointer};
@@ -10,7 +9,7 @@ use std::ptr::null_mut;
 #[derive(Debug)]
 pub struct JitState<'a> {
     pub(crate) state: *mut bindings::jit_state_t,
-    pub(crate) jit: &'a Jit,
+    pub(crate) phantom: std::marker::PhantomData<&'a ()>,
 }
 
 impl<'a> Drop for JitState<'a> {

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -87,7 +87,7 @@ macro_rules! jit_impl_type {
 macro_rules! jit_impl_inner {
     ( $op:ident, $ifmt:ident $(, $arg:ident: $type:ty => $target:ty)* ) => {
         paste::item! {
-            pub fn $op(&self $(, $arg: $type)*) -> JitNode<'a> {
+            pub fn $op(&mut self $(, $arg: $type)*) -> JitNode<'a> {
                 JitNode{
                     node: unsafe { bindings::[< _jit_new_node_ $ifmt >](self.state, bindings::[< jit_code_t_jit_code_ $op >] $(, jit_impl_type!($arg.to_ffi() => $target))*) },
                     phantom: std::marker::PhantomData,
@@ -103,7 +103,7 @@ macro_rules! jit_impl_inner {
 macro_rules! jit_reexport {
     ( $fn:ident $(, $arg:ident : $typ:ty )*; -> JitNode) => {
         paste::item! {
-            pub fn $fn(&self $(, $arg: $typ )*) -> JitNode<'a> {
+            pub fn $fn(&mut self $(, $arg: $typ )*) -> JitNode<'a> {
                 JitNode{
                     node: unsafe { bindings::[< _jit_ $fn >](self.state $(, $arg.to_ffi())*) },
                     phantom: std::marker::PhantomData,
@@ -113,14 +113,14 @@ macro_rules! jit_reexport {
     };
     ( $fn:ident $(, $arg:ident : $typ:ty )*; -> bool) => {
         paste::item! {
-            pub fn $fn(&self $(, $arg: $typ )*) -> bool {
+            pub fn $fn(&mut self $(, $arg: $typ )*) -> bool {
                 unsafe { bindings::[< _jit_ $fn >](self.state $(, $arg.to_ffi())*) != 0 }
             }
         }
     };
     ( $fn:ident $(, $arg:ident : $typ:ty )*; -> $ret:ty) => {
         paste::item! {
-            pub fn $fn(&self $(, $arg: $typ )*) -> $ret {
+            pub fn $fn(&mut self $(, $arg: $typ )*) -> $ret {
                 unsafe { bindings::[< _jit_ $fn >](self.state $(, $arg.to_ffi())*) }
             }
         }
@@ -138,7 +138,7 @@ macro_rules! jit_imm {
 macro_rules! jit_branch {
     ( $fn:ident, $t:ident ) => {
         paste::item! {
-            pub fn $fn(&self, a: Reg, b: jit_imm!($t)) -> JitNode<'a> {
+            pub fn $fn(&mut self, a: Reg, b: jit_imm!($t)) -> JitNode<'a> {
                 JitNode{
                     node: unsafe{ bindings::_jit_new_node_pww(self.state, bindings::[< jit_code_t_jit_code_ $fn >], null_mut::<c_void>(), a.to_ffi() as JitWord, b.to_ffi() as JitWord) },
                     phantom: std::marker::PhantomData,
@@ -150,12 +150,12 @@ macro_rules! jit_branch {
 
 macro_rules! jit_alias {
     ( $targ:ident => $new:ident $(, $arg:ident : $typ:ty )*; -> JitNode ) => {
-        pub fn $new(&self $(, $arg: $typ )*) -> JitNode<'a> {
+        pub fn $new(&mut self $(, $arg: $typ )*) -> JitNode<'a> {
             self.$targ($( $arg ),*)
         }
     };
     ( $targ:ident => $new:ident $(, $arg:ident : $typ:ty )*; -> $ret:ty) => {
-        pub fn $new(&self $(, $arg: $typ )*) -> $ret {
+        pub fn $new(&mut self $(, $arg: $typ )*) -> $ret {
             self.$targ($( $arg ),*)
         }
     };
@@ -164,7 +164,7 @@ macro_rules! jit_alias {
 
 /// `JitState` utility methods
 impl<'a> JitState<'a> {
-    pub fn clear(&self) {
+    pub fn clear(&mut self) {
         unsafe {
             bindings::_jit_clear_state(self.state);
         }
@@ -172,11 +172,11 @@ impl<'a> JitState<'a> {
 
     // there is no way to require a function type in a trait bound
     // without specifying the number of arguments
-    pub unsafe fn emit<T: Copy>(&self) -> T {
+    pub unsafe fn emit<T: Copy>(&mut self) -> T {
         *(&bindings::_jit_emit(self.state) as *const *mut core::ffi::c_void as *const T)
     }
 
-    pub fn raw_emit(&self) -> JitPointer {
+    pub fn raw_emit(&mut self) -> JitPointer {
         unsafe {
             bindings::_jit_emit(self.state)
         }
@@ -203,7 +203,7 @@ impl<'a> JitState<'a> {
     jit_impl!(live, w);
     jit_impl!(align, w);
 
-    pub fn name(&self, name: &str) -> JitNode<'a> {
+    pub fn name(&mut self, name: &str) -> JitNode<'a> {
         // I looked at the lightning code, this will be copied
         let cs = CString::new(name).unwrap();
         JitNode{
@@ -212,7 +212,7 @@ impl<'a> JitState<'a> {
         }
     }
 
-    pub fn note(&self, file: Option<&str>, line: u32) -> JitNode<'a> {
+    pub fn note(&mut self, file: Option<&str>, line: u32) -> JitNode<'a> {
         // I looked at the lightning code, this will be copied
         let cs = file
             .map(CString::new)
@@ -484,7 +484,7 @@ impl<'a> JitState<'a> {
 
     jit_impl!(jmpr, w);
 
-    pub fn jmpi(&self) -> JitNode<'a> {
+    pub fn jmpi(&mut self) -> JitNode<'a> {
         // I looked at the lightning code, this will be copied
         JitNode{
             node: unsafe { bindings::_jit_new_node_p(self.state, bindings::jit_code_t_jit_code_jmpi, std::ptr::null_mut::<c_void >()) },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! use lightning_sys::{Jit, Reg, JitPointer, JitWord};
 //!
 //! let mut jit = Jit::new();
-//! let js = jit.new_state();
+//! let mut js = jit.new_state();
 //!
 //! js.prolog();
 //! let inarg = js.arg();
@@ -32,7 +32,7 @@
 //!
 //! fn main() {
 //!     let mut jit = Jit::new();
-//!     let js = jit.new_state();
+//!     let mut js = jit.new_state();
 //!
 //!     // make sure this outlives any calls
 //!     let cs = CString::new("generated %d bytes\n").unwrap();
@@ -67,7 +67,7 @@
 //!
 //! fn main() {
 //!     let mut jit = Jit::new();
-//!     let js = jit.new_state();
+//!     let mut js = jit.new_state();
 //!
 //!     let label = js.label();
 //!                 js.prolog();
@@ -113,7 +113,7 @@
 //!
 //! fn main() {
 //!     let mut jit = Jit::new();
-//!     let js = jit.new_state();
+//!     let mut js = jit.new_state();
 //!
 //!     let fact = js.forward();
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! ```
 //! use lightning_sys::{Jit, Reg, JitPointer, JitWord};
 //!
-//! let jit = Jit::new();
+//! let mut jit = Jit::new();
 //! let js = jit.new_state();
 //!
 //! js.prolog();
@@ -31,7 +31,7 @@
 //! use std::convert::TryInto;
 //!
 //! fn main() {
-//!     let jit = Jit::new();
+//!     let mut jit = Jit::new();
 //!     let js = jit.new_state();
 //!
 //!     // make sure this outlives any calls
@@ -66,7 +66,7 @@
 //! use lightning_sys::{Jit, JitWord, Reg, JitPointer, NULL};
 //!
 //! fn main() {
-//!     let jit = Jit::new();
+//!     let mut jit = Jit::new();
 //!     let js = jit.new_state();
 //!
 //!     let label = js.label();
@@ -112,7 +112,7 @@
 //! use lightning_sys::{Jit, JitWord, Reg, NULL};
 //!
 //! fn main() {
-//!     let jit = Jit::new();
+//!     let mut jit = Jit::new();
 //!     let js = jit.new_state();
 //!
 //!     let fact = js.forward();


### PR DESCRIPTION
Fixes #29.

Since this is "semantic" `mut` and not borrowck-required `mut`, I may need to add some explanatory comments in the source code.