### PR TITLE
Switch from reqwest to ftp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ lazy_static = "1.4.0"
 bindgen = "0.53"
 cc = "1.0"
 flate2 = "1.0"
-reqwest = { version = "0.10", default-features = false, features = [ "blocking" ] }
+ftp = "3.0"
 tar = "0.4"
 
 [dev-dependencies]


### PR DESCRIPTION
In #20, `reqwest` was added as a build-dependency in order to avoid a dependency on `wget`, which is not always available.

Unfortunately, `reqwest` is has a huge number of dependencies of its own. It is a little embarrassing to have to download `reqwest` and its 69 unique dependencies just to be able to download a GNU lightning tarball. Instead, we can use `ftp` and its 22 unique dependencies. It is particularly noxious since `lightning-sys` has only 11 unique **non**-build dependencies.

Full disclosure : the GNU FTP server has this message :
```
<--- 230-NOTICE (Updated October 13 2017):
<--- 230-
<--- 230-Because of security concerns with plaintext protocols, we still
<--- 230-intend to disable the FTP protocol for downloads on this server
<--- 230-(downloads would still be available over HTTP and HTTPS), but we
<--- 230-will not be doing it on November 1, 2017, as previously announced
<--- 230-here. We will be sharing our reasons and offering a chance to
<--- 230-comment on this issue soon; watch this space for details.
<--- 230-
<--- 230-If you maintain scripts used to access ftp.gnu.org over FTP,
<--- 230-we strongly encourage you to change them to use HTTPS instead.
<--- 230-
```
However, I think that, precisely because many people have the same problem that the current PR tries to resolve, GNU will probably not remove its FTP server soon (note the date).

## Non-build dependencies of `lightning-sys`
```
$ cargo tree --edges no-build --prefix none | sort --unique | wc -l
      12
$ cargo tree --edges no-build
lightning-sys v0.2.1 (/private/var/folders/gk/205fyywj2tdc2brpy82s50wr0000gn/T/tmp.kcqYv7Wn)
├── lazy_static v1.4.0
└── paste v0.1.16
    ├── paste-impl v0.1.16
    │   ├── proc-macro-hack v0.5.16
    │   ├── proc-macro2 v1.0.18
    │   │   └── unicode-xid v0.2.0
    │   ├── quote v1.0.7
    │   │   └── proc-macro2 v1.0.18 (*)
    │   └── syn v1.0.31
    │       ├── proc-macro2 v1.0.18 (*)
    │       ├── quote v1.0.7 (*)
    │       └── unicode-xid v0.2.0
    └── proc-macro-hack v0.5.16
[dev-dependencies]
└── libc v0.2.71
```

## Dependencies of `ftp`
```
$ cargo tree --package ftp --prefix none | sort --unique | wc -l
      23
$ cargo tree --package ftp
ftp v3.0.1
├── chrono v0.2.25
│   ├── num v0.1.42
│   │   ├── num-integer v0.1.43
│   │   │   └── num-traits v0.2.12
│   │   │       [build-dependencies]
│   │   │       └── autocfg v1.0.0
│   │   │   [build-dependencies]
│   │   │   └── autocfg v1.0.0
│   │   ├── num-iter v0.1.41
│   │   │   ├── num-integer v0.1.43 (*)
│   │   │   └── num-traits v0.2.12 (*)
│   │   │   [build-dependencies]
│   │   │   └── autocfg v1.0.0
│   │   └── num-traits v0.2.12 (*)
│   └── time v0.1.43
│       └── libc v0.2.71
├── lazy_static v0.1.16
└── regex v0.1.80
    ├── aho-corasick v0.5.3
    │   └── memchr v0.1.11
    │       └── libc v0.2.71
    ├── memchr v0.1.11 (*)
    ├── regex-syntax v0.3.9
    ├── thread_local v0.2.7
    │   └── thread-id v2.0.0
    │       ├── kernel32-sys v0.2.2
    │       │   └── winapi v0.2.8
    │       │   [build-dependencies]
    │       │   └── winapi-build v0.1.1
    │       └── libc v0.2.71
    └── utf8-ranges v0.1.3
```
## Dependencies of `reqwest`
```
$ cargo tree --package reqwest --prefix none | sort --unique | wc -l
70
$ cargo tree --package reqwest
reqwest v0.10.6
├── base64 v0.12.1
├── bytes v0.5.4
├── encoding_rs v0.8.23
│   └── cfg-if v0.1.10
├── futures-core v0.3.5
├── futures-util v0.3.5
│   ├── futures-core v0.3.5
│   ├── futures-io v0.3.5
│   ├── futures-task v0.3.5
│   │   └── once_cell v1.4.0
│   ├── memchr v2.3.3
│   ├── pin-project v0.4.20
│   │   └── pin-project-internal v0.4.20
│   │       ├── proc-macro2 v1.0.18
│   │       │   └── unicode-xid v0.2.0
│   │       ├── quote v1.0.7
│   │       │   └── proc-macro2 v1.0.18 (*)
│   │       └── syn v1.0.31
│   │           ├── proc-macro2 v1.0.18 (*)
│   │           ├── quote v1.0.7 (*)
│   │           └── unicode-xid v0.2.0
│   ├── pin-utils v0.1.0
│   └── slab v0.4.2
├── http v0.2.1
│   ├── bytes v0.5.4
│   ├── fnv v1.0.7
│   └── itoa v0.4.5
├── http-body v0.3.1
│   ├── bytes v0.5.4
│   └── http v0.2.1 (*)
├── hyper v0.13.6
│   ├── bytes v0.5.4
│   ├── futures-channel v0.3.5
│   │   └── futures-core v0.3.5
│   ├── futures-core v0.3.5
│   ├── futures-util v0.3.5 (*)
│   ├── h2 v0.2.5
│   │   ├── bytes v0.5.4
│   │   ├── fnv v1.0.7
│   │   ├── futures-core v0.3.5
│   │   ├── futures-sink v0.3.5
│   │   ├── futures-util v0.3.5 (*)
│   │   ├── http v0.2.1 (*)
│   │   ├── indexmap v1.4.0
│   │   │   [build-dependencies]
│   │   │   └── autocfg v1.0.0
│   │   ├── log v0.4.8
│   │   │   └── cfg-if v0.1.10
│   │   ├── slab v0.4.2
│   │   ├── tokio v0.2.21
│   │   │   ├── bytes v0.5.4
│   │   │   ├── fnv v1.0.7
│   │   │   ├── futures-core v0.3.5
│   │   │   ├── iovec v0.1.4
│   │   │   │   └── libc v0.2.71
│   │   │   ├── lazy_static v1.4.0
│   │   │   ├── memchr v2.3.3
│   │   │   ├── mio v0.6.22
│   │   │   │   ├── cfg-if v0.1.10
│   │   │   │   ├── iovec v0.1.4 (*)
│   │   │   │   ├── libc v0.2.71
│   │   │   │   ├── log v0.4.8 (*)
│   │   │   │   ├── net2 v0.2.34
│   │   │   │   │   ├── cfg-if v0.1.10
│   │   │   │   │   └── libc v0.2.71
│   │   │   │   └── slab v0.4.2
│   │   │   ├── num_cpus v1.13.0
│   │   │   │   └── libc v0.2.71
│   │   │   ├── pin-project-lite v0.1.7
│   │   │   └── slab v0.4.2
│   │   └── tokio-util v0.3.1
│   │       ├── bytes v0.5.4
│   │       ├── futures-core v0.3.5
│   │       ├── futures-sink v0.3.5
│   │       ├── log v0.4.8 (*)
│   │       ├── pin-project-lite v0.1.7
│   │       └── tokio v0.2.21 (*)
│   ├── http v0.2.1 (*)
│   ├── http-body v0.3.1 (*)
│   ├── httparse v1.3.4
│   ├── itoa v0.4.5
│   ├── log v0.4.8 (*)
│   ├── pin-project v0.4.20 (*)
│   ├── socket2 v0.3.12
│   │   ├── cfg-if v0.1.10
│   │   └── libc v0.2.71
│   ├── time v0.1.43
│   │   └── libc v0.2.71
│   ├── tokio v0.2.21 (*)
│   ├── tower-service v0.3.0
│   └── want v0.3.0
│       ├── log v0.4.8 (*)
│       └── try-lock v0.2.2
├── lazy_static v1.4.0
├── log v0.4.8 (*)
├── mime v0.3.16
├── mime_guess v2.0.3
│   ├── mime v0.3.16
│   └── unicase v2.6.0
│       [build-dependencies]
│       └── version_check v0.9.2
│   [build-dependencies]
│   └── unicase v2.6.0 (*)
├── percent-encoding v2.1.0
├── pin-project-lite v0.1.7
├── serde v1.0.111
├── serde_urlencoded v0.6.1
│   ├── dtoa v0.4.5
│   ├── itoa v0.4.5
│   ├── serde v1.0.111
│   └── url v2.1.1
│       ├── idna v0.2.0
│       │   ├── matches v0.1.8
│       │   ├── unicode-bidi v0.3.4
│       │   │   └── matches v0.1.8
│       │   └── unicode-normalization v0.1.12
│       │       └── smallvec v1.4.0
│       ├── matches v0.1.8
│       └── percent-encoding v2.1.0
├── tokio v0.2.21 (*)
└── url v2.1.1 (*)
```