### PR TITLE
Export some more predicates

### DIFF
--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -178,6 +178,9 @@ impl<'a> JitState<'a> {
     jit_reexport!(forward_p, node: &JitNode; -> bool);
     jit_reexport!(indirect_p, node: &JitNode; -> bool);
     jit_reexport!(target_p, node: &JitNode; -> bool);
+    jit_reexport!(arg_register_p, node: &JitNode; -> bool);
+    jit_reexport!(callee_save_p, reg: Reg; -> bool);
+    jit_reexport!(pointer_p, ptr: JitPointer; -> bool);
 
     jit_reexport!(patch, instr: &JitNode);
     jit_reexport!(patch_at, instr: &JitNode, target: &JitNode);


### PR DESCRIPTION
From https://www.gnu.org/software/lightning/manual/lightning.html:

    arg_register_p (not specified)           argument kind predicate
    callee_save_p  (not specified)           callee save predicate
    pointer_p      (not specified)           pointer predicate

`arg_register_p` expects a `jit_node_t*` argument, that must have been
returned by `arg`, `arg_f` or `arg_d`, and will return non zero if the
argument lives in a register. This call is useful to know the live range
of register arguments, as those are very fast to read and write, but
have volatile values.

`callee_save_p` [expects] a valid `JIT_Rn`, `JIT_Vn`, or `JIT_Fn`, and
will return non zero if the register is callee save. This call is useful
because on several ports, the `JIT_Rn` and `JIT_Fn` registers are
actually callee save; no need to save and load the values when making
function calls.

`pointer_p` expects a pointer argument, and will return non zero if the
pointer is inside the generated jit code. Must be called after
`jit_emit` and before `jit_destroy_state`.