### PR TITLE
Avoid breakage from paste v0.1.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/petelliott/lightning-sys"
 documentation = "https://docs.rs/lightning-sys"
 
 [dependencies]
-paste = "0.1"
+paste = "0.1.18"
 lazy_static = "1.4.0"
 
 [build-dependencies]


### PR DESCRIPTION
This change avoids https://github.com/dtolnay/paste/issues/38 which affected `paste` v0.1.17.