### PR TITLE
Switch to attohttpc from reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ paste = "0.1.18"
 lazy_static = "1.4.0"
 
 [build-dependencies]
+attohttpc = { version = "0.15", default-features = false }
 bindgen = "0.53"
 cc = "1.0"
 flate2 = "1.0"
-reqwest = { version = "0.10", default-features = false, features = [ "blocking" ] }
 tar = "0.4"
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
+extern crate attohttpc;
 extern crate bindgen;
 extern crate flate2;
-extern crate reqwest;
 extern crate tar;
 
 use flate2::read::GzDecoder;
@@ -13,7 +13,7 @@ use tar::Archive;
 fn build_lightning(prefix: &str) -> Result<(), Box<dyn std::error::Error>> {
     let release = include_str!("release");
     let target = format!("http://ftp.gnu.org/gnu/lightning/{}.tar.gz", release);
-    unpack(reqwest::blocking::get(&target)?, prefix)?;
+    unpack(attohttpc::get(&target).send()?.split().2, prefix)?;
 
     let cflags = cc::Build::new().get_compiler().cflags_env();
     let flags = vec![


### PR DESCRIPTION
The [attohttpc crate](https://crates.io/crates/attohttpc) is much lighter-weight than [reqwest](https://crates.io/crates/reqwest) when all we need to do is download a tarball. Switching away from `reqwest` significantly improves initial build time.

For comparison, the Travis build for the current PR took [18m36s](https://travis-ci.com/github/Petelliott/lightning-sys/builds/173978061) total CPU time, compared to the most recent build on master, which took [24m6s](https://travis-ci.com/github/Petelliott/lightning-sys/builds/173262437).

The current PR has the same intent as #33, but the current PR is probably more portable and future-proof than that one.