### PR TITLE
Make wrapper.h unnecessary

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -68,7 +68,8 @@ fn main() {
     println!("cargo:rustc-link-lib=static=lightning");
 
     let bindings = bindgen::Builder::default()
-        .header("wrapper.h")
+        .header(incdir.join("lightning.h").to_str().unwrap())
+        .header("C/lightning-sys.h")
         // Tell bindgen to regenerate bindings if the wrapper.h's contents or transitively
         // included files change.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,2 +1,0 @@
-#include <lightning.h>
-#include "C/lightning-sys.h"


### PR DESCRIPTION
The `wrapper.h` header appeared to exist only to include other headers, and `bindgen` supports including multiple headers already.