### PR TITLE
Set a minimum supported Rust version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,22 +8,17 @@ arch:
   - amd64
 
 rust:
-  - nightly
-  - beta
   - stable
+  - beta
+  - nightly
 
 jobs:
   include:
-    - rust: stable
-      arch: arm64
-    - rust: stable
-      arch: s390x
-    - rust: stable
-      arch: ppc64le
-    - rust: stable
-      os: osx
-    - rust: stable
-      arch: amd64
+    - arch: arm64
+    - arch: s390x
+    - arch: ppc64le
+    - os: osx
+    - arch: amd64
       env: CARGO_BUILD_TARGET=i686-unknown-linux-gnu
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ arch:
 
 rust:
   - stable
+  - 1.39.0
   - beta
   - nightly
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 Safe gnu lightning bindings for rust
 
+## MSRV
+
+The minimum supported Rust version is **1.39**.
+
 ## Examples
 
 ### a function that increments a number by one


### PR DESCRIPTION
Due mainly to the MSRV of build-dependencies, our minimum supported Rust version is 1.39. Introduce a Travis check for this so we know when it changes.

Additionally, refactor the Travis YAML configuration slightly to reduce repetition of `stable`.