### PR TITLE
Mechanize interface generation, part 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lightning-sys"
 version = "0.2.2"
-authors = ["Peter Elliott <pelliott@ualberta.ca>"]
+authors = ["Peter Elliott <pelliott@ualberta.ca>", "Darren Kulp <darren@kulp.ch>"]
 edition = "2018"
 license = "LGPL-3.0-or-later"
 description = "GNU lightning bindings for rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/petelliott/lightning-sys"
 documentation = "https://docs.rs/lightning-sys"
 
 [dependencies]
-paste = "0.1.18"
 lazy_static = "1.4.0"
 tt-call = "1.0"
 

--- a/build.rs
+++ b/build.rs
@@ -76,13 +76,12 @@ fn chop_suffixes(orig: &str) -> Vec<&str> {
         return vec![orig];
     }
 
-    assert_eq!(num_underscores, 1);
-
     const SUFFIXES: &[&str] = &[
         "_f", "_d",
         "_u",
         "_c", "_i", "_l", "_s",
         "_uc", "_ui", "_ul", "_us",
+        "_p",
     ];
 
     for &suff in SUFFIXES {
@@ -340,7 +339,6 @@ fn main() -> std::io::Result<()> {
             .map(|(key, value)| {
                 (key.as_str(), std::str::from_utf8(value).unwrap())
             })
-            .filter(|(_, value)| value.contains("jit_new_node"))
             .collect();
 
     let output = make_printable(parse_macros(&relevant));

--- a/build.rs
+++ b/build.rs
@@ -180,7 +180,9 @@ fn make_variant_maps<'a>(
 ) -> (VariantMap<'a>, InverseVariantMap<'a>) {
     let kind_match = |needle: &str, haystack: &str| {
         let last_char = haystack.chars().last().unwrap();
-        let last_matches = (last_char == 'r' || last_char == 'i') && !haystack.contains('_');
+        let last_matches = (last_char == 'r' || last_char == 'i')
+            && !haystack.contains('_')
+            && haystack.len() > 1;
         haystack.starts_with(needle)
             && (haystack.len() - needle.len() < 2)
             && (haystack.len() == needle.len() || last_matches)

--- a/build.rs
+++ b/build.rs
@@ -111,36 +111,37 @@ type InverseVariantMap<'a> = BTreeMap<String,&'a str>;
 
 fn extract<'a>(
     variants: &impl Index<&'a str,Output=Pieces<'a>>,
-    inverse_variants: &impl Index<&'a str,Output=&'a str>,
+    inverse_variants: &BTreeMap<String,&'a str>,
     entry: &'a str,
     orig: &'a str,
-) -> Record {
+) -> Option<Record> {
     let brief = &entry[..entry.find('(').unwrap()];
     let core = brief.trim_start_matches("jit_");
-    let iv = &inverse_variants[core];
-    let pieces =
-        std::iter::once(iv.clone())
-            .chain(
-                variants[iv].iter()
-                    .find(|e| core == e.concat())
-                    .unwrap()
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(idx, v)|
-                         if idx == 0 {
-                             let v = v.trim_start_matches(iv);
-                             if v.is_empty() { None } else { Some(v) }
-                         } else {
-                             Some(v)
-                         }
-                    )
-            )
-            .map(ToString::to_string)
-            .collect::<Vec<_>>();
-    let stem = core.to_string();
-    let entry = entry.to_string();
-    let orig = orig.to_string();
-    Record { entry, stem, pieces, orig }
+    inverse_variants.get(core).and_then(|iv| {
+        let pieces =
+            std::iter::once(iv.clone())
+                .chain(
+                    variants[iv].iter()
+                        .find(|e| core == e.concat())
+                        .unwrap()
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(idx, v)|
+                             if idx == 0 {
+                                 let v = v.trim_start_matches(iv);
+                                 if v.is_empty() { None } else { Some(v) }
+                             } else {
+                                 Some(v)
+                             }
+                        )
+                )
+                .map(ToString::to_string)
+                .collect::<Vec<_>>();
+        let stem = core.to_string();
+        let entry = entry.to_string();
+        let orig = orig.to_string();
+        Some(Record { entry, stem, pieces, orig })
+    })
 }
 
 /// Takes a list of macro left-hand-sides (like `["jit_stxr_i(u,v,w)"]`) and
@@ -181,9 +182,10 @@ fn make_variant_maps<'a>(
 ) -> (VariantMap<'a>, InverseVariantMap<'a>) {
     let kind_match = |needle: &str, haystack: &str| {
         let last_char = haystack.chars().last().unwrap();
+        let last_matches = (last_char == 'r' || last_char == 'i') && !haystack.contains('_');
         haystack.starts_with(needle)
             && (haystack.len() - needle.len() < 2)
-            && (haystack.len() == needle.len() || last_char == 'r' || last_char == 'i')
+            && (haystack.len() == needle.len() || last_matches)
     };
     let variants: BTreeMap<_,Vec<_>> =
         roots
@@ -209,7 +211,7 @@ fn parse_macros<'a>(pairs: &[(&'a str,&'a str)]) -> Vec<Record> {
 
     pairs
         .iter()
-        .map(|(k, v)| extract(&variants, &inverse_variants, k, &v))
+        .filter_map(|(k, v)| extract(&variants, &inverse_variants, k, &v))
         .collect()
 }
 

--- a/build.rs
+++ b/build.rs
@@ -69,9 +69,7 @@ fn chop_suffixes(orig: &str) -> Vec<&str> {
 
     // Handle special internal movs
     if orig.starts_with("mov") && num_underscores > 1 {
-        // Accommodate the length of the initial "movr" or "movi".
-        // Treat multiple suffixes as one concatenated suffix in this case.
-        return vec![&orig[..4], &orig[4..]];
+        return orig.split('_').collect();
     }
 
     if num_underscores == 0 {

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -419,6 +419,8 @@ include!(concat!(env!("OUT_DIR"), "/entries.rs"));
 
 #[test]
 fn trivial_invocation() {
+    let mut entry_count = 0;
+
     trait MyDefault { fn default() -> Self; }
 
     impl MyDefault for f32        { fn default() -> Self { Default::default() } }
@@ -434,6 +436,7 @@ fn trivial_invocation() {
     macro_rules! mm {
         ( ( $entry:ident ( $( $inarg:ident ),* ) $root:ident ) => ( $( $types:ty ),* ) => ( $( $outarg:ident ),* ) ) => {
             {
+                entry_count += 1;
                 $( let $inarg = MyDefault::default(); )*
                 let _ = $crate::Jit::new().new_state().$root( $( $inarg ),* );
             }
@@ -458,6 +461,7 @@ fn trivial_invocation() {
             parts = [{ $stem:ident $( $suffix:ident )* }]
             invokes = [{ $invokes:ident( _jit $( , $outarg:ident )* ) }]
         } => {
+            entry_count += 1;
             // Allow disassembly to be configured out.
             #[cfg(disassembly)]
             #[allow(unreachable_code)]
@@ -479,6 +483,7 @@ fn trivial_invocation() {
             parts = [{ $stem:ident $( $suffix:ident )* }]
             invokes = [{ $invokes:ident( _jit $( , $outarg:ident )* ) }]
         } => {
+            entry_count += 1;
             #[allow(unreachable_code)]
             #[allow(unused_variables)]
             {
@@ -518,6 +523,7 @@ fn trivial_invocation() {
             parts = [{ $stem:ident $( $suffix:ident )* }]
             invokes = [{ $( $other:tt )+ }]
         } => {
+            entry_count += 1;
             // We cannot yet actually invoke these, but at least we can check
             // that the functions exist.
             let _ = JitState::$root;
@@ -531,5 +537,14 @@ fn trivial_invocation() {
     }
 
     include!{ concat!(env!("OUT_DIR"), "/entries.rs") }
+
+    // The exact number of entry points depends on things like the target
+    // architecture's word size, so we cannot robustly check for an exact
+    // number, but we can put some useful bounds on the number that allow us to
+    // catch egregious errors at least. We also do not necessarily want to break
+    // immediately when a new version of GNU lightning adds or removes a few
+    // entry points -- this is a sanity check only.
+    assert!(entry_count > 400, "not enough entry points were seen");
+    assert!(entry_count < 450, "too many entry points were seen");
 }
 

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -43,11 +43,6 @@ macro_rules! jit_reexport {
 }
 
 macro_rules! jit_alias {
-    ( $targ:ident => $new:ident $(, $arg:ident : $typ:ty )*; -> JitNode ) => {
-        pub fn $new(&mut self $(, $arg: $typ )*) -> JitNode<'a> {
-            self.$targ($( $arg ),*)
-        }
-    };
     ( $targ:ident => $new:ident $(, $arg:ident : $typ:ty )*; -> $ret:ty) => {
         pub fn $new(&mut self $(, $arg: $typ )*) -> $ret {
             self.$targ($( $arg ),*)
@@ -128,40 +123,40 @@ impl<'a> JitState<'a> {
     jit_alias!(getarg_i => getarg, reg: Reg, node: &JitNode<'a>);
 
     #[cfg(target_pointer_width = "32")]
-    jit_alias!(ldr_i => ldr, targ: Reg, src: Reg; -> JitNode);
+    jit_alias!(ldr_i => ldr, targ: Reg, src: Reg; -> JitNode<'a>);
     #[cfg(target_pointer_width = "32")]
-    jit_alias!(ldi_i => ldi, targ: Reg, src: JitPointer; -> JitNode);
+    jit_alias!(ldi_i => ldi, targ: Reg, src: JitPointer; -> JitNode<'a>);
     #[cfg(target_pointer_width = "64")]
-    jit_alias!(ldr_l => ldr, targ: Reg, src: Reg; -> JitNode);
+    jit_alias!(ldr_l => ldr, targ: Reg, src: Reg; -> JitNode<'a>);
     #[cfg(target_pointer_width = "64")]
-    jit_alias!(ldi_l => ldi, targ: Reg, src: JitPointer; -> JitNode);
+    jit_alias!(ldi_l => ldi, targ: Reg, src: JitPointer; -> JitNode<'a>);
 
     #[cfg(target_pointer_width = "32")]
-    jit_alias!(ldxr_i => ldxr, targ: Reg, a: Reg, b: Reg; -> JitNode);
+    jit_alias!(ldxr_i => ldxr, targ: Reg, a: Reg, b: Reg; -> JitNode<'a>);
     #[cfg(target_pointer_width = "32")]
-    jit_alias!(ldxi_i => ldxi, targ: Reg, src: Reg, off: JitWord; -> JitNode);
+    jit_alias!(ldxi_i => ldxi, targ: Reg, src: Reg, off: JitWord; -> JitNode<'a>);
     #[cfg(target_pointer_width = "64")]
-    jit_alias!(ldxr_l => ldxr, targ: Reg, a: Reg, b: Reg; -> JitNode);
+    jit_alias!(ldxr_l => ldxr, targ: Reg, a: Reg, b: Reg; -> JitNode<'a>);
     #[cfg(target_pointer_width = "64")]
-    jit_alias!(ldxi_l => ldxi, targ: Reg, src: Reg, off: JitWord; -> JitNode);
+    jit_alias!(ldxi_l => ldxi, targ: Reg, src: Reg, off: JitWord; -> JitNode<'a>);
 
     #[cfg(target_pointer_width = "32")]
-    jit_alias!(str_i => str, targ: Reg, src: Reg; -> JitNode);
+    jit_alias!(str_i => str, targ: Reg, src: Reg; -> JitNode<'a>);
     #[cfg(target_pointer_width = "32")]
-    jit_alias!(sti_i => sti, targ: JitPointer, src: Reg; -> JitNode);
+    jit_alias!(sti_i => sti, targ: JitPointer, src: Reg; -> JitNode<'a>);
     #[cfg(target_pointer_width = "64")]
-    jit_alias!(str_l => str, targ: Reg, src: Reg; -> JitNode);
+    jit_alias!(str_l => str, targ: Reg, src: Reg; -> JitNode<'a>);
     #[cfg(target_pointer_width = "64")]
-    jit_alias!(sti_i => sti, targ: JitPointer, src: Reg; -> JitNode);
+    jit_alias!(sti_i => sti, targ: JitPointer, src: Reg; -> JitNode<'a>);
 
     #[cfg(target_pointer_width = "32")]
-    jit_alias!(stxr_i => stxr, off: Reg, targ: Reg, src: Reg; -> JitNode);
+    jit_alias!(stxr_i => stxr, off: Reg, targ: Reg, src: Reg; -> JitNode<'a>);
     #[cfg(target_pointer_width = "32")]
-    jit_alias!(stxi_i => stxi, off: JitWord, targ: Reg, src: Reg; -> JitNode);
+    jit_alias!(stxi_i => stxi, off: JitWord, targ: Reg, src: Reg; -> JitNode<'a>);
     #[cfg(target_pointer_width = "64")]
-    jit_alias!(stxr_l => stxr, off: Reg, targ: Reg, src: Reg; -> JitNode);
+    jit_alias!(stxr_l => stxr, off: Reg, targ: Reg, src: Reg; -> JitNode<'a>);
     #[cfg(target_pointer_width = "64")]
-    jit_alias!(stxi_l => stxi, off: JitWord, targ: Reg, src: Reg; -> JitNode);
+    jit_alias!(stxi_l => stxi, off: JitWord, targ: Reg, src: Reg; -> JitNode<'a>);
 
     #[cfg(target_pointer_width = "32")]
     jit_alias!(retval_i => retval, rv: Reg);
@@ -169,14 +164,14 @@ impl<'a> JitState<'a> {
     jit_alias!(retval_l => retval, rv: Reg);
 
     #[cfg(target_pointer_width = "32")]
-    jit_alias!(truncr_f_i => truncr_f, int: Reg, float: Reg; -> JitNode);
+    jit_alias!(truncr_f_i => truncr_f, int: Reg, float: Reg; -> JitNode<'a>);
     #[cfg(target_pointer_width = "64")]
-    jit_alias!(truncr_f_l => truncr_f, int: Reg, float: Reg; -> JitNode);
+    jit_alias!(truncr_f_l => truncr_f, int: Reg, float: Reg; -> JitNode<'a>);
 
     #[cfg(target_pointer_width = "32")]
-    jit_alias!(truncr_d_i => truncr_d, int: Reg, float: Reg; -> JitNode);
+    jit_alias!(truncr_d_i => truncr_d, int: Reg, float: Reg; -> JitNode<'a>);
     #[cfg(target_pointer_width = "64")]
-    jit_alias!(truncr_d_l => truncr_d, int: Reg, float: Reg; -> JitNode);
+    jit_alias!(truncr_d_l => truncr_d, int: Reg, float: Reg; -> JitNode<'a>);
 }
 
 /// implmentations of general instructions

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -399,6 +399,8 @@ macro_rules! jit_inner {
     ( $( $any:tt )* ) => { compile_error!{ "Unrecognized jit_entry -- check formatting of generated macros" } };
 }
 
+/// Defines an inherent method for `JitState` for each `jit_entry` that
+/// corresponds to a `jit_new_node_*` call.
 macro_rules! jit_filtered {
     {
         $caller:tt

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -115,7 +115,7 @@ impl<'a> JitState<'a> {
     jit_reexport!(_jit_print, print);
 }
 
-/// implementations of word-size-dependent aliases
+/// implementations of word-size-dependent aliases and exports
 impl<'a> JitState<'a> {
     #[cfg(target_pointer_width = "64")]
     jit_alias!(getarg_l => getarg, reg: Reg, node: &JitNode<'a>);
@@ -172,6 +172,15 @@ impl<'a> JitState<'a> {
     jit_alias!(truncr_d_i => truncr_d, int: Reg, float: Reg; -> JitNode<'a>);
     #[cfg(target_pointer_width = "64")]
     jit_alias!(truncr_d_l => truncr_d, int: Reg, float: Reg; -> JitNode<'a>);
+
+    #[cfg(target_pointer_width = "64")]
+    jit_reexport!(_jit_getarg_ui, getarg_ui, reg: Reg, node: &JitNode<'a>);
+    #[cfg(target_pointer_width = "64")]
+    jit_reexport!(_jit_getarg_l, getarg_l, reg: Reg, node: &JitNode<'a>);
+    #[cfg(target_pointer_width = "64")]
+    jit_reexport!(_jit_retval_ui, retval_ui, rv: Reg);
+    #[cfg(target_pointer_width = "64")]
+    jit_reexport!(_jit_retval_l, retval_l, rv: Reg);
 }
 
 /// implementations of general instructions
@@ -217,10 +226,6 @@ impl<'a> JitState<'a> {
     jit_reexport!(_jit_getarg_s, getarg_s, reg: Reg, node: &JitNode<'a>);
     jit_reexport!(_jit_getarg_us, getarg_us, reg: Reg, node: &JitNode<'a>);
     jit_reexport!(_jit_getarg_i, getarg_i, reg: Reg, node: &JitNode<'a>);
-    #[cfg(target_pointer_width = "64")]
-    jit_reexport!(_jit_getarg_ui, getarg_ui, reg: Reg, node: &JitNode<'a>);
-    #[cfg(target_pointer_width = "64")]
-    jit_reexport!(_jit_getarg_l, getarg_l, reg: Reg, node: &JitNode<'a>);
 
     jit_reexport!(_jit_putargr, putargr, reg: Reg, arg: &JitNode<'a>);
     jit_reexport!(_jit_putargi, putargi, imm: JitWord, arg: &JitNode<'a>);
@@ -262,10 +267,6 @@ impl<'a> JitState<'a> {
     jit_reexport!(_jit_retval_s, retval_s, rv: Reg);
     jit_reexport!(_jit_retval_us, retval_us, rv: Reg);
     jit_reexport!(_jit_retval_i, retval_i, rv: Reg);
-    #[cfg(target_pointer_width = "64")]
-    jit_reexport!(_jit_retval_ui, retval_ui, rv: Reg);
-    #[cfg(target_pointer_width = "64")]
-    jit_reexport!(_jit_retval_l, retval_l, rv: Reg);
     jit_reexport!(_jit_epilog, epilog);
 
     jit_reexport!(_jit_frame, frame, size: i32);

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -419,6 +419,28 @@ macro_rules! jit_filtered {
     };
 }
 
+macro_rules! jit_entry_non_node {
+    {
+        $caller:tt
+        decl = [{ $entry:ident( $( $inarg:ident ),* ) }]
+        root = [{ destroy_state }]
+        parts = [{ $stem:ident $( $suffix:ident )* }]
+        invokes = [{ $invokes:ident( $( $outarg:ident ),* ) }]
+    } => {
+        make_func! {
+            func = [{ $stem }]
+            body = [{ unsafe { self.$entry( $( $inarg ),* ) } }]
+            rettype = [{ () }]
+            parmhead = [{ self, }] // Takes `self` by move, NOT by reference
+            parmnames = [{ }]
+            parmtypes = [{ }]
+        }
+    };
+    { $( $tokens:tt )* } => {
+        // Ignore these for now.
+    };
+}
+
 include!(concat!(env!("OUT_DIR"), "/entries.rs"));
 
 #[test]
@@ -452,16 +474,6 @@ fn trivial_invocation() {
     /// Calls the function represented by each `jit_entry` that does *not*
     /// correspond to a `jit_new_node_*` call.
     macro_rules! jit_entry_non_node {
-        {
-            $caller:tt
-            decl = [{ $entry:ident( $( $inarg:ident ),* ) }]
-            root = [{ destroy_state }]
-            parts = [{ $stem:ident $( $suffix:ident )* }]
-            invokes = [{ $( $other:tt )* }]
-        } => {
-            // Ignore jit_destroy_state, since it gets turned into a Drop
-            // implementation and destroying before Drop seems problematic.
-        };
         {
             $caller:tt
             decl = [{ $entry:ident( $( $inarg:ident ),* ) }]

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -21,31 +21,25 @@ impl<'a> Drop for JitState<'a> {
 }
 
 macro_rules! jit_reexport {
-    ( $fn:ident $(, $arg:ident : $typ:ty )*; -> JitNode) => {
-        paste::item! {
-            pub fn $fn(&mut self $(, $arg: $typ )*) -> JitNode<'a> {
-                JitNode{
-                    node: unsafe { bindings::[< _jit_ $fn >](self.state $(, $arg.to_ffi())*) },
-                    phantom: std::marker::PhantomData,
-                }
+    ( $orig:ident, $fn:ident $(, $arg:ident : $typ:ty )*; -> JitNode) => {
+        pub fn $fn(&mut self $(, $arg: $typ )*) -> JitNode<'a> {
+            JitNode{
+                node: unsafe { bindings::$orig(self.state $(, $arg.to_ffi())*) },
+                phantom: std::marker::PhantomData,
             }
         }
     };
-    ( $fn:ident $(, $arg:ident : $typ:ty )*; -> bool) => {
-        paste::item! {
-            pub fn $fn(&mut self $(, $arg: $typ )*) -> bool {
-                unsafe { bindings::[< _jit_ $fn >](self.state $(, $arg.to_ffi())*) != 0 }
-            }
+    ( $orig:ident, $fn:ident $(, $arg:ident : $typ:ty )*; -> bool) => {
+        pub fn $fn(&mut self $(, $arg: $typ )*) -> bool {
+            unsafe { bindings::$orig(self.state $(, $arg.to_ffi())*) != 0 }
         }
     };
-    ( $fn:ident $(, $arg:ident : $typ:ty )*; -> $ret:ty) => {
-        paste::item! {
-            pub fn $fn(&mut self $(, $arg: $typ )*) -> $ret {
-                unsafe { bindings::[< _jit_ $fn >](self.state $(, $arg.to_ffi())*) }
-            }
+    ( $orig:ident, $fn:ident $(, $arg:ident : $typ:ty )*; -> $ret:ty) => {
+        pub fn $fn(&mut self $(, $arg: $typ )*) -> $ret {
+            unsafe { bindings::$orig(self.state $(, $arg.to_ffi())*) }
         }
     };
-    ( $fn:ident $(, $arg:ident : $typ:ty )*) => { jit_reexport!($fn $(, $arg : $typ)*; -> ()); }
+    ( $orig:ident, $fn:ident $(, $arg:ident : $typ:ty )*) => { jit_reexport!($orig, $fn $(, $arg : $typ)*; -> ()); }
 }
 
 macro_rules! jit_alias {
@@ -81,21 +75,21 @@ impl<'a> JitState<'a> {
         *(&self.emit() as *const *mut core::ffi::c_void as *const T)
     }
 
-    jit_reexport!(emit; -> JitPointer);
+    jit_reexport!(_jit_emit, emit; -> JitPointer);
 
-    jit_reexport!(address, node: &JitNode; -> JitPointer);
+    jit_reexport!(_jit_address, address, node: &JitNode; -> JitPointer);
 
-    jit_reexport!(forward_p, node: &JitNode; -> bool);
-    jit_reexport!(indirect_p, node: &JitNode; -> bool);
-    jit_reexport!(target_p, node: &JitNode; -> bool);
-    jit_reexport!(arg_register_p, node: &JitNode; -> bool);
-    jit_reexport!(callee_save_p, reg: Reg; -> bool);
-    jit_reexport!(pointer_p, ptr: JitPointer; -> bool);
+    jit_reexport!(_jit_forward_p, forward_p, node: &JitNode; -> bool);
+    jit_reexport!(_jit_indirect_p, indirect_p, node: &JitNode; -> bool);
+    jit_reexport!(_jit_target_p, target_p, node: &JitNode; -> bool);
+    jit_reexport!(_jit_arg_register_p, arg_register_p, node: &JitNode; -> bool);
+    jit_reexport!(_jit_callee_save_p, callee_save_p, reg: Reg; -> bool);
+    jit_reexport!(_jit_pointer_p, pointer_p, ptr: JitPointer; -> bool);
 
-    jit_reexport!(patch, instr: &JitNode);
-    jit_reexport!(patch_at, instr: &JitNode, target: &JitNode);
-    jit_reexport!(patch_abs, instr: &JitNode, target: JitPointer);
-    jit_reexport!(realize);
+    jit_reexport!(_jit_patch, patch, instr: &JitNode);
+    jit_reexport!(_jit_patch_at, patch_at, instr: &JitNode, target: &JitNode);
+    jit_reexport!(_jit_patch_abs, patch_abs, instr: &JitNode, target: JitPointer);
+    jit_reexport!(_jit_realize, realize);
 
     // get_code needs argument mangling that jit_reexport currently does not
     // provide
@@ -103,7 +97,7 @@ impl<'a> JitState<'a> {
         unsafe { bindings::_jit_get_code(self.state, pointer_from(code_size)) }
     }
 
-    jit_reexport!(set_code, buf: JitPointer, size: JitWord; -> ());
+    jit_reexport!(_jit_set_code, set_code, buf: JitPointer, size: JitWord; -> ());
 
     // get_data needs argument mangling that jit_reexport currently does not
     // provide
@@ -121,9 +115,9 @@ impl<'a> JitState<'a> {
         }
     }
 
-    jit_reexport!(set_data, buf: JitPointer, data_size: JitWord, flags: JitWord; -> ());
+    jit_reexport!(_jit_set_data, set_data, buf: JitPointer, data_size: JitWord, flags: JitWord; -> ());
 
-    jit_reexport!(print);
+    jit_reexport!(_jit_print, print);
 }
 
 /// implementations of word-size-dependent aliases
@@ -210,51 +204,37 @@ impl<'a> JitState<'a> {
         }
     }
 
-    jit_reexport!(label; -> JitNode);
-    jit_reexport!(forward; -> JitNode);
-    jit_reexport!(indirect; -> JitNode);
-    jit_reexport!(link, node: &JitNode);
+    jit_reexport!(_jit_label, label; -> JitNode);
+    jit_reexport!(_jit_forward, forward; -> JitNode);
+    jit_reexport!(_jit_indirect, indirect; -> JitNode);
+    jit_reexport!(_jit_link, link, node: &JitNode);
 
-    jit_reexport!(prolog);
-    jit_reexport!(ellipsis);
+    jit_reexport!(_jit_prolog, prolog);
+    jit_reexport!(_jit_ellipsis, ellipsis);
 
-    jit_reexport!(allocai, size: i32; -> i32);
-    jit_reexport!(allocar, off: Reg, size: Reg);
+    jit_reexport!(_jit_allocai, allocai, size: i32; -> i32);
+    jit_reexport!(_jit_allocar, allocar, off: Reg, size: Reg);
 
-    jit_reexport!(arg; -> JitNode);
+    jit_reexport!(_jit_arg, arg; -> JitNode);
 
-    jit_reexport!(getarg_c, reg: Reg, node: &JitNode);
-    jit_reexport!(getarg_uc, reg: Reg, node: &JitNode);
-    jit_reexport!(getarg_s, reg: Reg, node: &JitNode);
-    jit_reexport!(getarg_us, reg: Reg, node: &JitNode);
-    jit_reexport!(getarg_i, reg: Reg, node: &JitNode);
+    jit_reexport!(_jit_getarg_c, getarg_c, reg: Reg, node: &JitNode);
+    jit_reexport!(_jit_getarg_uc, getarg_uc, reg: Reg, node: &JitNode);
+    jit_reexport!(_jit_getarg_s, getarg_s, reg: Reg, node: &JitNode);
+    jit_reexport!(_jit_getarg_us, getarg_us, reg: Reg, node: &JitNode);
+    jit_reexport!(_jit_getarg_i, getarg_i, reg: Reg, node: &JitNode);
     #[cfg(target_pointer_width = "64")]
-    jit_reexport!(getarg_ui, reg: Reg, node: &JitNode);
+    jit_reexport!(_jit_getarg_ui, getarg_ui, reg: Reg, node: &JitNode);
     #[cfg(target_pointer_width = "64")]
-    jit_reexport!(getarg_l, reg: Reg, node: &JitNode);
+    jit_reexport!(_jit_getarg_l, getarg_l, reg: Reg, node: &JitNode);
 
-    jit_reexport!(putargr, reg: Reg, arg: &JitNode);
-    jit_reexport!(putargi, imm: JitWord, arg: &JitNode);
+    jit_reexport!(_jit_putargr, putargr, reg: Reg, arg: &JitNode);
+    jit_reexport!(_jit_putargi, putargi, imm: JitWord, arg: &JitNode);
 
-    jit_reexport!(va_push, arg: Reg);
+    jit_reexport!(_jit_va_push, va_push, arg: Reg);
 
     pub fn rsbr(&mut self, a: Reg, b: Reg, c: Reg) -> JitNode<'a> {
         self.subr(a, c, b)
     }
-
-    jit_reexport!(prepare);
-    jit_reexport!(pushargr, arg: Reg);
-    jit_reexport!(pushargi, arg: JitWord);
-    jit_reexport!(finishr, arg: Reg);
-    jit_reexport!(finishi, arg: JitPointer; -> JitNode);
-    jit_reexport!(ret);
-    jit_reexport!(retr, rv: Reg);
-    jit_reexport!(reti, rv: JitWord);
-    jit_reexport!(retval_c, rv: Reg);
-    jit_reexport!(retval_uc, rv: Reg);
-    jit_reexport!(retval_s, rv: Reg);
-    jit_reexport!(retval_us, rv: Reg);
-    jit_reexport!(retval_i, rv: Reg);
 
     pub fn get_note(
         &self,
@@ -274,50 +254,63 @@ impl<'a> JitState<'a> {
         }
     }
 
+    jit_reexport!(_jit_prepare, prepare);
+    jit_reexport!(_jit_pushargr, pushargr, arg: Reg);
+    jit_reexport!(_jit_pushargi, pushargi, arg: JitWord);
+    jit_reexport!(_jit_finishr, finishr, arg: Reg);
+    jit_reexport!(_jit_finishi, finishi, arg: JitPointer; -> JitNode);
+    jit_reexport!(_jit_ret, ret);
+    jit_reexport!(_jit_retr, retr, rv: Reg);
+    jit_reexport!(_jit_reti, reti, rv: JitWord);
+    jit_reexport!(_jit_retval_c, retval_c, rv: Reg);
+    jit_reexport!(_jit_retval_uc, retval_uc, rv: Reg);
+    jit_reexport!(_jit_retval_s, retval_s, rv: Reg);
+    jit_reexport!(_jit_retval_us, retval_us, rv: Reg);
+    jit_reexport!(_jit_retval_i, retval_i, rv: Reg);
     #[cfg(target_pointer_width = "64")]
-    jit_reexport!(retval_ui, rv: Reg);
+    jit_reexport!(_jit_retval_ui, retval_ui, rv: Reg);
     #[cfg(target_pointer_width = "64")]
-    jit_reexport!(retval_l, rv: Reg);
-    jit_reexport!(epilog);
+    jit_reexport!(_jit_retval_l, retval_l, rv: Reg);
+    jit_reexport!(_jit_epilog, epilog);
 
-    jit_reexport!(frame, size: i32);
-    jit_reexport!(tramp, fsize: i32);
+    jit_reexport!(_jit_frame, frame, size: i32);
+    jit_reexport!(_jit_tramp, tramp, fsize: i32);
 }
 
 /// implmentations of 32-bit float instructions
 impl<'a> JitState<'a> {
-    jit_reexport!(arg_f; -> JitNode);
-    jit_reexport!(getarg_f, reg: Reg, arg: &JitNode);
-    jit_reexport!(putargr_f, reg: Reg, arg: &JitNode);
-    jit_reexport!(putargi_f, imm: f32, arg: &JitNode);
+    jit_reexport!(_jit_arg_f, arg_f; -> JitNode);
+    jit_reexport!(_jit_getarg_f, getarg_f, reg: Reg, arg: &JitNode);
+    jit_reexport!(_jit_putargr_f, putargr_f, reg: Reg, arg: &JitNode);
+    jit_reexport!(_jit_putargi_f, putargi_f, imm: f32, arg: &JitNode);
 
     pub fn rsbr_f(&mut self, a: Reg, b: Reg, c: Reg) -> JitNode<'a> {
         self.subr_f(a, c, b)
     }
 
-    jit_reexport!(pushargr_f, reg: Reg);
-    jit_reexport!(pushargi_f, imm: f32);
-    jit_reexport!(retr_f, reg: Reg);
-    jit_reexport!(reti_f, imm: f32);
-    jit_reexport!(retval_f, reg: Reg);
+    jit_reexport!(_jit_pushargr_f, pushargr_f, reg: Reg);
+    jit_reexport!(_jit_pushargi_f, pushargi_f, imm: f32);
+    jit_reexport!(_jit_retr_f, retr_f, reg: Reg);
+    jit_reexport!(_jit_reti_f, reti_f, imm: f32);
+    jit_reexport!(_jit_retval_f, retval_f, reg: Reg);
 }
 
 /// implmentations of 64-bit float instructions
 impl<'a> JitState<'a> {
-    jit_reexport!(arg_d; -> JitNode);
-    jit_reexport!(getarg_d, reg: Reg, arg: &JitNode);
-    jit_reexport!(putargr_d, reg: Reg, arg: &JitNode);
-    jit_reexport!(putargi_d, imm: f64, arg: &JitNode);
+    jit_reexport!(_jit_arg_d, arg_d; -> JitNode);
+    jit_reexport!(_jit_getarg_d, getarg_d, reg: Reg, arg: &JitNode);
+    jit_reexport!(_jit_putargr_d, putargr_d, reg: Reg, arg: &JitNode);
+    jit_reexport!(_jit_putargi_d, putargi_d, imm: f64, arg: &JitNode);
 
     pub fn rsbr_d(&mut self, a: Reg, b: Reg, c: Reg) -> JitNode<'a> {
         self.subr_d(a, c, b)
     }
 
-    jit_reexport!(pushargr_d, reg: Reg);
-    jit_reexport!(pushargi_d, imm: f64);
-    jit_reexport!(retr_d, reg: Reg);
-    jit_reexport!(reti_d, imm: f64);
-    jit_reexport!(retval_d, reg: Reg);
+    jit_reexport!(_jit_pushargr_d, pushargr_d, reg: Reg);
+    jit_reexport!(_jit_pushargi_d, pushargi_d, imm: f64);
+    jit_reexport!(_jit_retr_d, retr_d, reg: Reg);
+    jit_reexport!(_jit_reti_d, reti_d, imm: f64);
+    jit_reexport!(_jit_retval_d, retval_d, reg: Reg);
 }
 
 macro_rules! private_make_func {

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -174,7 +174,7 @@ impl<'a> JitState<'a> {
     jit_alias!(truncr_d_l => truncr_d, int: Reg, float: Reg; -> JitNode<'a>);
 }
 
-/// implmentations of general instructions
+/// implementations of general instructions
 impl<'a> JitState<'a> {
 
     pub fn name(&mut self, name: &str) -> JitNode<'a> {
@@ -272,7 +272,7 @@ impl<'a> JitState<'a> {
     jit_reexport!(_jit_tramp, tramp, fsize: i32);
 }
 
-/// implmentations of 32-bit float instructions
+/// implementations of 32-bit float instructions
 impl<'a> JitState<'a> {
     jit_reexport!(_jit_arg_f, arg_f; -> JitNode<'a>);
     jit_reexport!(_jit_getarg_f, getarg_f, reg: Reg, arg: &JitNode<'a>);
@@ -290,7 +290,7 @@ impl<'a> JitState<'a> {
     jit_reexport!(_jit_retval_f, retval_f, reg: Reg);
 }
 
-/// implmentations of 64-bit float instructions
+/// implementations of 64-bit float instructions
 impl<'a> JitState<'a> {
     jit_reexport!(_jit_arg_d, arg_d; -> JitNode<'a>);
     jit_reexport!(_jit_getarg_d, getarg_d, reg: Reg, arg: &JitNode<'a>);

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -3,8 +3,8 @@ use crate::Reg;
 use crate::JitNode;
 use crate::{JitWord, JitPointer};
 use crate::ToFFI;
-use std::ffi::{CString, c_void};
-use std::ptr::null_mut;
+use std::ffi::CString;
+use tt_call::*;
 
 #[derive(Debug)]
 pub struct JitState<'a> {
@@ -18,80 +18,6 @@ impl<'a> Drop for JitState<'a> {
             bindings::_jit_destroy_state(self.state);
         }
     }
-}
-
-
-macro_rules! jit_impl {
-    ( $op:ident, _ ) => { jit_impl_inner!($op, _); };
-
-    ( $op:ident, w ) => { jit_impl_inner!($op, w, a: Reg => JitWord); };
-    //( $op:ident, f ) => { jit_impl_inner!($op, f, a: Reg => JitWord); };
-    //( $op:ident, d ) => { jit_impl_inner!($op, d, a: Reg => JitWord); };
-    //( $op:ident, p ) => { jit_impl_inner!($op, p, a: Reg => JitWord); };
-
-    ( $op:ident, i_w ) => { jit_impl_inner!($op, w, a: JitWord => _); };
-    ( $op:ident, i_f ) => { jit_impl_inner!($op, f, a: f32 => _); };
-    ( $op:ident, i_d ) => { jit_impl_inner!($op, d, a: f64 => _); };
-    ( $op:ident, i_p ) => { jit_impl_inner!($op, p, a: JitPointer => _); };
-
-    ( $op:ident, ww ) => { jit_impl_inner!($op, ww, a: Reg => JitWord, b: Reg => JitWord); };
-    //( $op:ident, wp ) => { jit_impl_inner!($op, wp, a: Reg => JitWord, b: Reg => JitWord); };
-    //( $op:ident, fp ) => { jit_impl_inner!($op, fp, a: Reg => JitWord, b: Reg => JitWord); };
-    //( $op:ident, dp ) => { jit_impl_inner!($op, dp, a: Reg => JitWord, b: Reg => JitWord); };
-    //( $op:ident, pw ) => { jit_impl_inner!($op, pw, a: Reg => JitWord, b: Reg => JitWord); };
-    //( $op:ident, wf ) => { jit_impl_inner!($op, wf, a: Reg => JitWord, b: Reg => JitWord); };
-    //( $op:ident, wd ) => { jit_impl_inner!($op, wd, a: Reg => JitWord, b: Reg => JitWord); };
-
-    ( $op:ident, i_ww ) => { jit_impl_inner!($op, ww, a: Reg => JitWord, b: JitWord => _); };
-    ( $op:ident, i_wp ) => { jit_impl_inner!($op, wp, a: Reg => JitWord, b: JitPointer => _); };
-    ( $op:ident, i_fp ) => { jit_impl_inner!($op, fp, a: Reg => JitWord, b: JitPointer => _); };
-    ( $op:ident, i_dp ) => { jit_impl_inner!($op, dp, a: Reg => JitWord, b: JitPointer => _); };
-    ( $op:ident, i_pw ) => { jit_impl_inner!($op, pw, a: JitPointer => _, b: Reg => JitWord); };
-    ( $op:ident, i_wf ) => { jit_impl_inner!($op, wf, a: Reg => JitWord, b: f32 => _); };
-    ( $op:ident, i_wd ) => { jit_impl_inner!($op, wd, a: Reg => JitWord, b: f64 => _); };
-
-    ( $op:ident, www ) => { jit_impl_inner!($op, www, a: Reg => JitWord, b: Reg => JitWord, c: Reg => JitWord); };
-    //( $op:ident, wwf ) => { jit_impl_inner!($op, wwf, a: Reg => JitWord, b: Reg => JitWord, c: Reg => JitWord); };
-    //( $op:ident, wwd ) => { jit_impl_inner!($op, wwd, a: Reg => JitWord, b: Reg => JitWord, c: Reg => JitWord); };
-    //( $op:ident, pww ) => { jit_impl_inner!($op, pww, a: Reg => JitWord, b: Reg => JitWord, c: Reg => JitWord); };
-    //( $op:ident, pwf ) => { jit_impl_inner!($op, pwf, a: Reg => JitWord, b: Reg => JitWord, c: Reg => JitWord); };
-    //( $op:ident, pwd ) => { jit_impl_inner!($op, pwd, a: Reg => JitWord, b: Reg => JitWord, c: Reg => JitWord); };
-
-    ( $op:ident, i_www ) => { jit_impl_inner!($op, www, a: Reg => JitWord, b: Reg => JitWord, c: JitWord => _); };
-    ( $op:ident, i_wwf ) => { jit_impl_inner!($op, wwf, a: Reg => JitWord, b: Reg => JitWord, c: f32 => _); };
-    ( $op:ident, i_wwd ) => { jit_impl_inner!($op, wwd, a: Reg => JitWord, b: Reg => JitWord, c: f64 => _); };
-    ( $op:ident, i_pww ) => { jit_impl_inner!($op, pww, a: Reg => JitWord, b: Reg => JitWord, c: JitWord => _); };
-    ( $op:ident, i_pwf ) => { jit_impl_inner!($op, pwf, a: Reg => JitWord, b: Reg => JitWord, c: f32 => _); };
-    ( $op:ident, i_pwd ) => { jit_impl_inner!($op, pwd, a: Reg => JitWord, b: Reg => JitWord, c: f64 => _); };
-
-    ( $op:ident, qww ) => { jit_impl_inner!($op, qww, a: Reg => i32, b: Reg => i32, c: Reg => JitWord, d: Reg => JitWord); };
-    ( $op:ident, i_qww ) => { jit_impl_inner!($op, qww, a: Reg => i32, b: Reg => i32, c: Reg => JitWord, d: JitWord => _); };
-}
-
-macro_rules! jit_store {
-    ( $op:ident, ww ) => { jit_impl_inner!($op, ww, a: Reg => JitWord, b: Reg => JitWord); };
-
-    ( $op:ident, i_pw ) => { jit_impl_inner!($op, pw, a: JitPointer => _, b: Reg => JitWord); };
-
-    ( $op:ident, www ) => { jit_impl_inner!($op, www, a: Reg => JitWord, b: Reg => JitWord, c: Reg => JitWord); };
-
-    ( $op:ident, i_www ) => { jit_impl_inner!($op, www, a: JitWord => _, b: Reg => JitWord, c: Reg => JitWord); };
-
-}
-
-macro_rules! jit_impl_inner {
-    ( $op:ident, $ifmt:ident $(, $arg:ident: $type:ty => $target:ty)* ) => {
-        paste::item! {
-            pub fn $op(&mut self $(, $arg: $type)*) -> JitNode<'a> {
-                unsafe {
-                    self.[< jit_ $op >]($( $arg.to_ffi().into() ),*)
-                }
-            }
-        }
-    };
-    ( $op:ident, $ifmt:ident $(, $arg:ident: $type:ty)* ) => {
-        jit_impl_inner!(kkk);
-    };
 }
 
 macro_rules! jit_reexport {
@@ -120,26 +46,6 @@ macro_rules! jit_reexport {
         }
     };
     ( $fn:ident $(, $arg:ident : $typ:ty )*) => { jit_reexport!($fn $(, $arg : $typ)*; -> ()); }
-}
-
-macro_rules! jit_imm {
-    (i) => { JitWord };
-    (r) => { Reg };
-    (f) => { f32 };
-    (d) => { f64 };
-}
-
-macro_rules! jit_branch {
-    ( $fn:ident, $t:ident ) => {
-        paste::item! {
-            pub fn $fn(&mut self, a: Reg, b: jit_imm!($t)) -> JitNode<'a> {
-                JitNode{
-                    node: unsafe{ bindings::_jit_new_node_pww(self.state, bindings::jit_code_t::[< jit_code_ $fn >], null_mut::<c_void>(), a.to_ffi() as JitWord, b.to_ffi() as JitWord) },
-                    phantom: std::marker::PhantomData,
-                }
-            }
-        }
-    };
 }
 
 macro_rules! jit_alias {
@@ -281,8 +187,6 @@ impl<'a> JitState<'a> {
 
 /// implmentations of general instructions
 impl<'a> JitState<'a> {
-    jit_impl!(live, w);
-    jit_impl!(align, w);
 
     pub fn name(&mut self, name: &str) -> JitNode<'a> {
         // I looked at the lightning code, this will be copied
@@ -332,227 +236,11 @@ impl<'a> JitState<'a> {
     jit_reexport!(putargr, reg: Reg, arg: &JitNode);
     jit_reexport!(putargi, imm: JitWord, arg: &JitNode);
 
-    jit_impl!(va_start, w);
-    jit_impl!(va_arg, ww);
-    jit_impl!(va_arg_d, ww);
     jit_reexport!(va_push, arg: Reg);
-    jit_impl!(va_end, w);
-
-    jit_impl!(addr, www);
-    jit_impl!(addi, i_www);
-    jit_impl!(addcr, www);
-    jit_impl!(addci, i_www);
-    jit_impl!(addxr, www);
-    jit_impl!(addxi, i_www);
-    jit_impl!(subr, www);
-    jit_impl!(subi, i_www);
-    jit_impl!(subcr, www);
-    jit_impl!(subci, i_www);
-    jit_impl!(subxr, www);
-    jit_impl!(subxi, i_www);
 
     pub fn rsbr(&mut self, a: Reg, b: Reg, c: Reg) -> JitNode<'a> {
         self.subr(a, c, b)
     }
-
-    jit_impl!(rsbi, i_www);
-
-    jit_impl!(mulr, www);
-    jit_impl!(muli, i_www);
-    jit_impl!(qmulr, qww);
-    jit_impl!(qmuli, i_qww);
-    jit_impl!(qmulr_u, qww);
-    jit_impl!(qmuli_u, i_qww);
-    jit_impl!(divr, www);
-    jit_impl!(divi, i_www);
-    jit_impl!(divr_u, www);
-    jit_impl!(divi_u, i_www);
-    jit_impl!(qdivr, qww);
-    jit_impl!(qdivi, i_qww);
-    jit_impl!(qdivr_u, qww);
-    jit_impl!(qdivi_u, i_qww);
-    jit_impl!(remr, www);
-    jit_impl!(remi, i_www);
-    jit_impl!(remr_u, www);
-    jit_impl!(remi_u, i_www);
-
-    jit_impl!(andr, www);
-    jit_impl!(andi, i_www);
-    jit_impl!(orr, www);
-    jit_impl!(ori, i_www);
-    jit_impl!(xorr, www);
-    jit_impl!(xori, i_www);
-
-    jit_impl!(lshr, www);
-    jit_impl!(lshi, i_www);
-    jit_impl!(rshr, www);
-    jit_impl!(rshi, i_www);
-    jit_impl!(rshi_u, i_www);
-    jit_impl!(rshr_u, www);
-
-    jit_impl!(negr, ww);
-    jit_impl!(comr, ww);
-
-    jit_impl!(ltr, www);
-    jit_impl!(lti, i_www);
-    jit_impl!(ltr_u, www);
-    jit_impl!(lti_u, i_www);
-    jit_impl!(ler, www);
-    jit_impl!(lei, i_www);
-    jit_impl!(ler_u, www);
-    jit_impl!(lei_u, i_www);
-    jit_impl!(eqr, www);
-    jit_impl!(eqi, i_www);
-    jit_impl!(ger, www);
-    jit_impl!(ger_u, www);
-    jit_impl!(gei, i_www);
-    jit_impl!(gei_u, i_www);
-    jit_impl!(gtr, www);
-    jit_impl!(gti, i_www);
-    jit_impl!(gtr_u, www);
-    jit_impl!(gti_u, i_www);
-    jit_impl!(ner, www);
-    jit_impl!(nei, i_www);
-
-    jit_impl!(movr, ww);
-    jit_impl!(movi, i_ww);
-
-    jit_impl!(extr_c, ww);
-    jit_impl!(extr_uc, ww);
-    jit_impl!(extr_s, ww);
-    jit_impl!(extr_us, ww);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(extr_i, ww);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(extr_ui, ww);
-
-    jit_impl!(htonr_us, ww);
-    jit_alias!(htonr_us => ntohr_us, targ: Reg, src: Reg; -> JitNode);
-    jit_impl!(htonr_ui, ww);
-    jit_alias!(htonr_ui => ntohr_ui, targ: Reg, src: Reg; -> JitNode);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(htonr_ul, ww);
-    #[cfg(target_pointer_width = "64")]
-    jit_alias!(htonr_ul => ntohr_ul, targ: Reg, src: Reg; -> JitNode);
-    #[cfg(target_pointer_width = "32")]
-    jit_alias!(htonr_ui => htonr, targ: Reg, src: Reg; -> JitNode);
-    #[cfg(target_pointer_width = "64")]
-    jit_alias!(htonr_ul => htonr, targ: Reg, src: Reg; -> JitNode);
-    jit_alias!(htonr => ntohr, targ: Reg, src: Reg; -> JitNode);
-
-    jit_impl!(ldr_c, ww);
-    jit_impl!(ldi_c, i_wp);
-    jit_impl!(ldr_uc, ww);
-    jit_impl!(ldi_uc, i_wp);
-    jit_impl!(ldr_s, ww);
-    jit_impl!(ldi_s, i_wp);
-    jit_impl!(ldr_us, ww);
-    jit_impl!(ldi_us, i_wp);
-    jit_impl!(ldr_i, ww);
-    jit_impl!(ldi_i, i_wp);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(ldr_ui, ww);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(ldi_ui, i_wp);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(ldr_l, ww);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(ldi_l, i_wp);
-
-    jit_impl!(ldxr_c, www);
-    jit_impl!(ldxi_c, i_www);
-    jit_impl!(ldxr_uc, www);
-    jit_impl!(ldxi_uc, i_www);
-    jit_impl!(ldxr_s, www);
-    jit_impl!(ldxi_s, i_www);
-    jit_impl!(ldxr_us, www);
-    jit_impl!(ldxi_us, i_www);
-    jit_impl!(ldxr_i, www);
-    jit_impl!(ldxi_i, i_www);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(ldxr_ui, www);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(ldxi_ui, i_www);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(ldxr_l, www);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(ldxi_l, i_www);
-
-    jit_store!(str_c, ww);
-    jit_store!(sti_c, i_pw);
-    jit_store!(str_s, ww);
-    jit_store!(sti_s, i_pw);
-    jit_store!(str_i, ww);
-    jit_store!(sti_i, i_pw);
-    #[cfg(target_pointer_width = "64")]
-    jit_store!(str_l, ww);
-    #[cfg(target_pointer_width = "64")]
-    jit_store!(sti_l, i_pw);
-
-    jit_store!(stxr_c, www);
-    jit_store!(stxi_c, i_www);
-    jit_store!(stxr_s, www);
-    jit_store!(stxi_s, i_www);
-    jit_store!(stxr_i, www);
-    jit_store!(stxi_i, i_www);
-    #[cfg(target_pointer_width = "64")]
-    jit_store!(stxr_l, www);
-    #[cfg(target_pointer_width = "64")]
-    jit_store!(stxi_l, i_www);
-
-    jit_branch!(bltr, r);
-    jit_branch!(blti, i);
-    jit_branch!(bltr_u, r);
-    jit_branch!(blti_u, i);
-    jit_branch!(bler, r);
-    jit_branch!(blei, i);
-    jit_branch!(bler_u, r);
-    jit_branch!(blei_u, i);
-    jit_branch!(beqr, r);
-    jit_branch!(beqi, i);
-    jit_branch!(bger, r);
-    jit_branch!(bgei, i);
-    jit_branch!(bger_u, r);
-    jit_branch!(bgei_u, i);
-    jit_branch!(bgtr, r);
-    jit_branch!(bgti, i);
-    jit_branch!(bgtr_u, r);
-    jit_branch!(bgti_u, i);
-    jit_branch!(bner, r);
-    jit_branch!(bnei, i);
-    jit_branch!(bmsr, r);
-    jit_branch!(bmsi, i);
-    jit_branch!(bmcr, r);
-    jit_branch!(bmci, i);
-    jit_branch!(boaddr, r);
-    jit_branch!(boaddi, i);
-    jit_branch!(boaddr_u, r);
-    jit_branch!(boaddi_u, i);
-    jit_branch!(bxaddr, r);
-    jit_branch!(bxaddi, i);
-    jit_branch!(bxaddr_u, r);
-    jit_branch!(bxaddi_u, i);
-    jit_branch!(bosubr, r);
-    jit_branch!(bosubi, i);
-    jit_branch!(bosubr_u, r);
-    jit_branch!(bosubi_u, i);
-    jit_branch!(bxsubr, r);
-    jit_branch!(bxsubi, i);
-    jit_branch!(bxsubr_u, r);
-    jit_branch!(bxsubi_u, i);
-
-    jit_impl!(jmpr, w);
-
-    pub fn jmpi(&mut self) -> JitNode<'a> {
-        // I looked at the lightning code, this will be copied
-        JitNode{
-            node: unsafe { bindings::_jit_new_node_p(self.state, bindings::jit_code_t::jit_code_jmpi, std::ptr::null_mut::<c_void >()) },
-            phantom: std::marker::PhantomData,
-        }
-    }
-
-    jit_impl!(callr, w);
-    jit_impl!(calli, i_p);
 
     jit_reexport!(prepare);
     jit_reexport!(pushargr, arg: Reg);
@@ -603,100 +291,9 @@ impl<'a> JitState<'a> {
     jit_reexport!(putargr_f, reg: Reg, arg: &JitNode);
     jit_reexport!(putargi_f, imm: f32, arg: &JitNode);
 
-    jit_impl!(addr_f, www);
-    jit_impl!(addi_f, i_wwf);
-    jit_impl!(subr_f, www);
-    jit_impl!(subi_f, i_wwf);
-
     pub fn rsbr_f(&mut self, a: Reg, b: Reg, c: Reg) -> JitNode<'a> {
         self.subr_f(a, c, b)
     }
-
-    jit_impl!(rsbi_f, i_wwf);
-    jit_impl!(mulr_f, www);
-    jit_impl!(muli_f, i_wwf);
-    jit_impl!(divr_f, www);
-    jit_impl!(divi_f, i_wwf);
-    jit_impl!(negr_f, ww);
-    jit_impl!(absr_f, ww);
-    jit_impl!(sqrtr_f, ww);
-
-    jit_impl!(ltr_f, www);
-    jit_impl!(lti_f, i_wwf);
-    jit_impl!(ler_f, www);
-    jit_impl!(lei_f, i_wwf);
-    jit_impl!(eqr_f, www);
-    jit_impl!(eqi_f, i_wwf);
-    jit_impl!(ger_f, www);
-    jit_impl!(gei_f, i_wwf);
-    jit_impl!(gtr_f, www);
-    jit_impl!(gti_f, i_wwf);
-    jit_impl!(ner_f, www);
-    jit_impl!(nei_f, i_wwf);
-    jit_impl!(unltr_f, www);
-    jit_impl!(unlti_f, i_wwf);
-    jit_impl!(unler_f, www);
-    jit_impl!(unlei_f, i_wwf);
-    jit_impl!(uneqr_f, www);
-    jit_impl!(uneqi_f, i_wwf);
-    jit_impl!(unger_f, www);
-    jit_impl!(ungei_f, i_wwf);
-    jit_impl!(ungtr_f, www);
-    jit_impl!(ungti_f, i_wwf);
-    jit_impl!(ltgtr_f, www);
-    jit_impl!(ltgti_f, i_wwf);
-    jit_impl!(ordr_f, www);
-    jit_impl!(ordi_f, i_wwf);
-    jit_impl!(unordr_f, www);
-    jit_impl!(unordi_f, i_wwf);
-
-    jit_impl!(truncr_f_i, ww);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(truncr_f_l, ww);
-
-    jit_impl!(extr_f, ww);
-    jit_impl!(extr_d_f, ww);
-    jit_impl!(movr_f, ww);
-    jit_impl!(movi_f, i_wf);
-
-    jit_impl!(ldr_f, ww);
-    jit_impl!(ldi_f, i_wp);
-    jit_impl!(ldxr_f, www);
-    jit_impl!(ldxi_f, i_www);
-
-    jit_store!(str_f, ww);
-    jit_store!(sti_f, i_pw);
-    jit_store!(stxr_f, www);
-    jit_store!(stxi_f, i_www);
-
-    jit_branch!(bltr_f, r);
-    jit_branch!(blti_f, f);
-    jit_branch!(bler_f, r);
-    jit_branch!(blei_f, f);
-    jit_branch!(beqr_f, r);
-    jit_branch!(beqi_f, f);
-    jit_branch!(bger_f, r);
-    jit_branch!(bgei_f, f);
-    jit_branch!(bgtr_f, r);
-    jit_branch!(bgti_f, f);
-    jit_branch!(bner_f, r);
-    jit_branch!(bnei_f, f);
-    jit_branch!(bunltr_f, r);
-    jit_branch!(bunlti_f, f);
-    jit_branch!(bunler_f, r);
-    jit_branch!(bunlei_f, f);
-    jit_branch!(buneqr_f, r);
-    jit_branch!(buneqi_f, f);
-    jit_branch!(bunger_f, r);
-    jit_branch!(bungei_f, f);
-    jit_branch!(bungtr_f, r);
-    jit_branch!(bungti_f, f);
-    jit_branch!(bltgtr_f, r);
-    jit_branch!(bltgti_f, f);
-    jit_branch!(bordr_f, r);
-    jit_branch!(bordi_f, f);
-    jit_branch!(bunordr_f, r);
-    jit_branch!(bunordi_f, f);
 
     jit_reexport!(pushargr_f, reg: Reg);
     jit_reexport!(pushargi_f, imm: f32);
@@ -712,100 +309,9 @@ impl<'a> JitState<'a> {
     jit_reexport!(putargr_d, reg: Reg, arg: &JitNode);
     jit_reexport!(putargi_d, imm: f64, arg: &JitNode);
 
-    jit_impl!(addr_d, www);
-    jit_impl!(addi_d, i_wwd);
-    jit_impl!(subr_d, www);
-    jit_impl!(subi_d, i_wwd);
-
     pub fn rsbr_d(&mut self, a: Reg, b: Reg, c: Reg) -> JitNode<'a> {
         self.subr_d(a, c, b)
     }
-
-    jit_impl!(rsbi_d, i_wwd);
-    jit_impl!(mulr_d, www);
-    jit_impl!(muli_d, i_wwd);
-    jit_impl!(divr_d, www);
-    jit_impl!(divi_d, i_wwd);
-    jit_impl!(negr_d, ww);
-    jit_impl!(absr_d, ww);
-    jit_impl!(sqrtr_d, ww);
-
-    jit_impl!(ltr_d, www);
-    jit_impl!(lti_d, i_wwd);
-    jit_impl!(ler_d, www);
-    jit_impl!(lei_d, i_wwd);
-    jit_impl!(eqr_d, www);
-    jit_impl!(eqi_d, i_wwd);
-    jit_impl!(ger_d, www);
-    jit_impl!(gei_d, i_wwd);
-    jit_impl!(gtr_d, www);
-    jit_impl!(gti_d, i_wwd);
-    jit_impl!(ner_d, www);
-    jit_impl!(nei_d, i_wwd);
-    jit_impl!(unltr_d, www);
-    jit_impl!(unlti_d, i_wwd);
-    jit_impl!(unler_d, www);
-    jit_impl!(unlei_d, i_wwd);
-    jit_impl!(uneqr_d, www);
-    jit_impl!(uneqi_d, i_wwd);
-    jit_impl!(unger_d, www);
-    jit_impl!(ungei_d, i_wwd);
-    jit_impl!(ungtr_d, www);
-    jit_impl!(ungti_d, i_wwd);
-    jit_impl!(ltgtr_d, www);
-    jit_impl!(ltgti_d, i_wwd);
-    jit_impl!(ordr_d, www);
-    jit_impl!(ordi_d, i_wwd);
-    jit_impl!(unordr_d, www);
-    jit_impl!(unordi_d, i_wwd);
-
-    jit_impl!(truncr_d_i, ww);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(truncr_d_l, ww);
-
-    jit_impl!(extr_d, ww);
-    jit_impl!(extr_f_d, ww);
-    jit_impl!(movr_d, ww);
-    jit_impl!(movi_d, i_wd);
-
-    jit_impl!(ldr_d, ww);
-    jit_impl!(ldi_d, i_wp);
-    jit_impl!(ldxr_d, www);
-    jit_impl!(ldxi_d, i_www);
-
-    jit_store!(str_d, ww);
-    jit_store!(sti_d, i_pw);
-    jit_store!(stxr_d, www);
-    jit_store!(stxi_d, i_www);
-
-    jit_branch!(bltr_d, r);
-    jit_branch!(blti_d, d);
-    jit_branch!(bler_d, r);
-    jit_branch!(blei_d, d);
-    jit_branch!(beqr_d, r);
-    jit_branch!(beqi_d, d);
-    jit_branch!(bger_d, r);
-    jit_branch!(bgei_d, d);
-    jit_branch!(bgtr_d, r);
-    jit_branch!(bgti_d, d);
-    jit_branch!(bner_d, r);
-    jit_branch!(bnei_d, d);
-    jit_branch!(bunltr_d, r);
-    jit_branch!(bunlti_d, d);
-    jit_branch!(bunler_d, r);
-    jit_branch!(bunlei_d, d);
-    jit_branch!(buneqr_d, r);
-    jit_branch!(buneqi_d, d);
-    jit_branch!(bunger_d, r);
-    jit_branch!(bungei_d, d);
-    jit_branch!(bungtr_d, r);
-    jit_branch!(bungti_d, d);
-    jit_branch!(bltgtr_d, r);
-    jit_branch!(bltgti_d, d);
-    jit_branch!(bordr_d, r);
-    jit_branch!(bordi_d, d);
-    jit_branch!(bunordr_d, r);
-    jit_branch!(bunordi_d, d);
 
     jit_reexport!(pushargr_d, reg: Reg);
     jit_reexport!(pushargi_d, imm: f64);
@@ -813,3 +319,142 @@ impl<'a> JitState<'a> {
     jit_reexport!(reti_d, imm: f64);
     jit_reexport!(retval_d, reg: Reg);
 }
+
+macro_rules! private_make_func {
+    {
+        func = [{ $fname:ident $( < $( $life:lifetime ),+ > )? }]
+        body = [{ $( $body:tt )* }]
+        rettype = [{ $rettype:ty }]
+        parmhead = [{ $( $parmhead:tt )* }]
+        zipped = [{ $( $params:tt )* }]
+    } => {
+        pub fn $fname $( < $( $life ),+ > )? ( $( $parmhead )* $( $params )* ) -> $rettype {
+            $( $body )*
+        }
+    };
+}
+
+macro_rules! mm {
+    ( ( $entry:ident ( $( $inarg:ident ),* ) $root:ident ) => ( $( $types:ty ),* ) => ( $( $outarg:ident ),* ) ) => {
+        make_func! {
+            func = [{ $root }]
+            body = [{
+                unsafe {
+                    self.$entry( $( $inarg.to_ffi().into() ),* )
+                }
+            }]
+            rettype = [{ JitNode<'j> }]
+            parmhead = [{ &mut self, }]
+            parmnames = [{ $( $inarg ),* }]
+            parmtypes = [{ $( $types ),* }]
+        }
+    };
+}
+
+/// Infer immediate type
+macro_rules! it {
+    ( _d ) => { f64 };
+    ( _f ) => { f32 };
+    (    ) => { JitWord };
+}
+
+macro_rules! jit_inner {
+    // Ignores (by name) ---------------------------------------------------------------------------------------
+    // Bottom-level new-node
+    ( $a:tt [ new_node $(, $y:tt)* ] => $n:tt            $r:tt ) => { /* not part of the public interface */  };
+    // Internal movs
+    ( $a:tt [ mov, i, $k:tt, $w:tt ] => $n:tt            $r:tt ) => { /* not part of the public interface */  };
+    ( $a:tt [ mov, r, $k:tt, $w:tt ] => $n:tt            $r:tt ) => { /* not part of the public interface */  };
+
+    // Handlers (by name) --------------------------------------------------------------------------------------
+    // Immediate calls and jumps
+    ( $a:tt [ call, i              ] => $n:tt            $r:tt ) => { mm!{ $a => (JitPointer)         => $r } };
+    ( $a:tt [ jmp, i               ] => $n:tt            $r:tt ) => { mm!{ $a => ()                   => $r } };
+    // All ldi, sti, stxi (ldxi is handled by the jit_new_node_www catch-all)
+    ( $a:tt [ ld, i    $(, $y:tt)? ] => $n:tt            $r:tt ) => { mm!{ $a => (Reg, JitPointer)    => $r } };
+    ( $a:tt [ st, i    $(, $y:tt)? ] => $n:tt            $r:tt ) => { mm!{ $a => (JitPointer, Reg)    => $r } };
+    ( $a:tt [ stx, i   $(, $y:tt)? ] => $n:tt            $r:tt ) => { mm!{ $a => (JitWord, Reg, Reg)  => $r } };
+    // Movs
+    ( $a:tt [ mov, i   $(, $y:tt)? ] => $n:tt            $r:tt ) => { mm!{ $a => (Reg, it!{$($y)?})   => $r } };
+    // Varargs
+    ( $a:tt [ va_arg $(, _d)?      ] => $n:tt            $r:tt ) => { mm!{ $a => (Reg, Reg)           => $r } };
+
+    // Catch-alls (by signature) -------------------------------------------------------------------------------
+    // All quad instructions
+    ( $a:tt [ $q:tt, i $(, $y:tt)* ] => jit_new_node_qww $r:tt ) => { mm!{ $a => (i32, i32, Reg, Reg) => $r } };
+    ( $a:tt [ $q:tt, r $(, $y:tt)* ] => jit_new_node_qww $r:tt ) => { mm!{ $a => (Reg, Reg, Reg, Reg) => $r } };
+    // Branches
+    ( $a:tt [ $q:tt    $(, $y:tt)* ] => jit_new_node_pwd $r:tt ) => { mm!{ $a => (Reg, f64)           => $r } };
+    ( $a:tt [ $q:tt    $(, $y:tt)* ] => jit_new_node_pwf $r:tt ) => { mm!{ $a => (Reg, f32)           => $r } };
+    ( $a:tt [ $q:tt, r $(, $y:tt)* ] => jit_new_node_pww $r:tt ) => { mm!{ $a => (Reg, Reg)           => $r } };
+    ( $a:tt [ $q:tt, i $(, $y:tt)* ] => jit_new_node_pww $r:tt ) => { mm!{ $a => (Reg, JitWord)       => $r } };
+    // All jit_new_node_ww[fd]
+    ( $a:tt [ $q:tt, i, _d         ] => jit_new_node_wwd $r:tt ) => { mm!{ $a => (Reg, Reg, f64)      => $r } };
+    ( $a:tt [ $q:tt, i, _f         ] => jit_new_node_wwf $r:tt ) => { mm!{ $a => (Reg, Reg, f32)      => $r } };
+    // All jit_new_node_w+
+    ( $a:tt [ $q:tt, r             ] => jit_new_node_w   $r:tt ) => { mm!{ $a => (Reg)                => $r } };
+    ( $a:tt [ $q:tt                ] => jit_new_node_w   $r:tt ) => { mm!{ $a => (JitWord)            => $r } };
+    ( $a:tt [ $q:tt, r $(, $y:tt)* ] => jit_new_node_ww  $r:tt ) => { mm!{ $a => (Reg, Reg)           => $r } };
+    ( $a:tt [ $q:tt, i $(, $y:tt)? ] => jit_new_node_www $r:tt ) => { mm!{ $a => (Reg, Reg, JitWord)  => $r } };
+    ( $a:tt [ $q:tt, r $(, $y:tt)? ] => jit_new_node_www $r:tt ) => { mm!{ $a => (Reg, Reg, Reg)      => $r } };
+
+    // Fallbacks (generic patterns) ----------------------------------------------------------------------------
+    (   ( $entry:ident ( $( $inarg:ident ),* ) $root:ident )
+          [ $stem:ident $( , $suffix:ident )* ]
+          => $invokes:ident( $enum:ident $( , $outarg:ident )* )
+    ) => {
+        // Ensure all patterns are caught explicitly before this
+        compile_error!{ "Unhandled jit_entry -- jit_inner needs to be updated with a new pattern" }
+    };
+
+    ( $( $any:tt )* ) => { compile_error!{ "Unrecognized jit_entry -- check formatting of generated macros" } };
+}
+
+macro_rules! jit_entry {
+    (   $entry:ident( $( $inarg:ident ),* )
+          => $root:ident
+          => [ $stem:ident $( , $suffix:ident )* ]
+          => $invokes:ident( $enum:ident $( , $outarg:ident )* )
+    ) => {
+        jit_inner!{
+            ( $entry ( $( $inarg ),* ) $root )
+              [ $stem $( , $suffix )* ]
+              => $invokes( $enum $( , $outarg )* )
+        }
+    };
+}
+
+include!(concat!(env!("OUT_DIR"), "/entries.rs"));
+
+#[test]
+fn trivial_invocation() {
+    trait MyDefault { fn default() -> Self; }
+
+    impl MyDefault for f32        { fn default() -> Self { Default::default() } }
+    impl MyDefault for f64        { fn default() -> Self { Default::default() } }
+
+    #[cfg(target_pointer_width = "64")] /* avoid conflicting with JitWord */
+    impl MyDefault for i32        { fn default() -> Self { Default::default() } }
+
+    impl MyDefault for JitWord    { fn default() -> Self { Default::default() } }
+    impl MyDefault for Reg        { fn default() -> Self { Reg::R(0)          } }
+    impl MyDefault for JitPointer { fn default() -> Self { crate::types::NULL } }
+
+    macro_rules! mm {
+        ( ( $entry:ident ( $( $inarg:ident ),* ) $root:ident ) => ( $( $types:ty ),* ) => ( $( $outarg:ident ),* ) ) => {
+            {
+                $( let $inarg = MyDefault::default(); )*
+                let _ = $crate::Jit::new().new_state().$root( $( $inarg ),* );
+            }
+        };
+    }
+
+    macro_rules! jit_entries {
+        ( $( $tokens:tt )* ) => {
+            { $( $tokens )* }
+        };
+    }
+
+    include!{ concat!(env!("OUT_DIR"), "/entries.rs") }
+}
+

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -444,6 +444,90 @@ fn trivial_invocation() {
         };
     }
 
+    macro_rules! jit_entry_non_node {
+        {
+            $caller:tt
+            decl = [{ $entry:ident( $( $inarg:ident ),* ) }]
+            root = [{ destroy_state }]
+            parts = [{ $stem:ident $( $suffix:ident )* }]
+            invokes = [{ $( $other:tt )* }]
+        } => {
+            // Ignore jit_destroy_state, since it gets turned into a Drop
+            // implementation and destroying before Drop seems problematic.
+        };
+        {
+            $caller:tt
+            decl = [{ $entry:ident( $( $inarg:ident ),* ) }]
+            root = [{ disassemble }]
+            parts = [{ $stem:ident $( $suffix:ident )* }]
+            invokes = [{ $invokes:ident( _jit $( , $outarg:ident )* ) }]
+        } => {
+            // Allow disassembly to be configured out.
+            #[cfg(disassembly)]
+            #[allow(unreachable_code)]
+            #[allow(unused_variables)]
+            {
+                if false {
+                    // We cannot yet actually invoke these, but at least we can
+                    // check that the functions exist and take the right number
+                    // of parameters.
+                    $( let $outarg = unimplemented!(); )*
+                    let _ = $crate::Jit::new().new_state().disassemble( $( $outarg ),* );
+                }
+            }
+        };
+        {
+            $caller:tt
+            decl = [{ $entry:ident( $( $inarg:ident ),* ) }]
+            root = [{ $root:ident }]
+            parts = [{ $stem:ident $( $suffix:ident )* }]
+            invokes = [{ $invokes:ident( _jit $( , $outarg:ident )* ) }]
+        } => {
+            #[allow(unreachable_code)]
+            #[allow(unused_variables)]
+            {
+                if false {
+                    // We cannot yet actually invoke these, but at least we can
+                    // check that the functions exist and take the right number
+                    // of parameters.
+                    $( let $outarg = unimplemented!(); )*
+                    let _ = $crate::Jit::new().new_state().$root( $( $outarg ),* );
+                }
+            }
+        };
+        {
+            $caller:tt
+            decl = [{ $entry:ident( $( $inarg:ident ),* ) }]
+            root = [{ $root:ident }]
+            parts = [{ $stem:ident $( $suffix:ident )* }]
+            invokes = [{ jit_cpu $( $other:tt )* }]
+        } => {
+            // Ignore macros that expand to an expression referencing
+            // architecture-specific details.
+        };
+        {
+            $caller:tt
+            decl = [{ $entry:ident( $( $inarg:ident ),* ) }]
+            root = [{ $root:ident }]
+            parts = [{ $stem:ident $( $suffix:ident )* }]
+            invokes = [{ $other:tt }]
+        } => {
+            // For now, ignore macros that expand to an expression that is not a
+            // function call.
+        };
+        {
+            $caller:tt
+            decl = [{ $entry:ident( $( $inarg:ident ),* ) }]
+            root = [{ $root:ident }]
+            parts = [{ $stem:ident $( $suffix:ident )* }]
+            invokes = [{ $( $other:tt )+ }]
+        } => {
+            // We cannot yet actually invoke these, but at least we can check
+            // that the functions exist.
+            let _ = JitState::$root;
+        };
+    }
+
     macro_rules! jit_entries {
         ( $( $tokens:tt )* ) => {
             { $( $tokens )* }

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -79,18 +79,12 @@ macro_rules! jit_store {
 
 }
 
-macro_rules! jit_impl_type {
-    ( $e:expr => _ ) => { $e };
-    ( $e:expr => $t:ty ) => { $e as $t };
-}
-
 macro_rules! jit_impl_inner {
     ( $op:ident, $ifmt:ident $(, $arg:ident: $type:ty => $target:ty)* ) => {
         paste::item! {
             pub fn $op(&mut self $(, $arg: $type)*) -> JitNode<'a> {
-                JitNode{
-                    node: unsafe { bindings::[< _jit_new_node_ $ifmt >](self.state, bindings::jit_code_t::[< jit_code_ $op >] $(, jit_impl_type!($arg.to_ffi() => $target))*) },
-                    phantom: std::marker::PhantomData,
+                unsafe {
+                    self.[< jit_ $op >]($( $arg.to_ffi().into() ),*)
                 }
             }
         }

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -403,16 +403,18 @@ macro_rules! jit_inner {
     ( $( $any:tt )* ) => { compile_error!{ "Unrecognized jit_entry -- check formatting of generated macros" } };
 }
 
-macro_rules! jit_entry {
-    (   $entry:ident( $( $inarg:ident ),* )
-          => $root:ident
-          => [ $stem:ident $( , $suffix:ident )* ]
-          => $invokes:ident( $enum:ident $( , $outarg:ident )* )
-    ) => {
+macro_rules! jit_filtered {
+    {
+        $caller:tt
+        decl = [{ $entry:ident $inargs:tt }]
+        root = [{ $root:ident }]
+        parts = [{ $( $parts:ident )* }]
+        invokes = [{ $invokes:ident $outargs:tt }]
+    } => {
         jit_inner!{
-            ( $entry ( $( $inarg ),* ) $root )
-              [ $stem $( , $suffix )* ]
-              => $invokes( $enum $( , $outarg )* )
+            ( $entry $inargs $root )
+              [ $( $parts ),* ]
+              => $invokes $outargs
         }
     };
 }

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -77,18 +77,18 @@ impl<'a> JitState<'a> {
 
     jit_reexport!(_jit_emit, emit; -> JitPointer);
 
-    jit_reexport!(_jit_address, address, node: &JitNode; -> JitPointer);
+    jit_reexport!(_jit_address, address, node: &JitNode<'a>; -> JitPointer);
 
-    jit_reexport!(_jit_forward_p, forward_p, node: &JitNode; -> bool);
-    jit_reexport!(_jit_indirect_p, indirect_p, node: &JitNode; -> bool);
-    jit_reexport!(_jit_target_p, target_p, node: &JitNode; -> bool);
-    jit_reexport!(_jit_arg_register_p, arg_register_p, node: &JitNode; -> bool);
+    jit_reexport!(_jit_forward_p, forward_p, node: &JitNode<'a>; -> bool);
+    jit_reexport!(_jit_indirect_p, indirect_p, node: &JitNode<'a>; -> bool);
+    jit_reexport!(_jit_target_p, target_p, node: &JitNode<'a>; -> bool);
+    jit_reexport!(_jit_arg_register_p, arg_register_p, node: &JitNode<'a>; -> bool);
     jit_reexport!(_jit_callee_save_p, callee_save_p, reg: Reg; -> bool);
     jit_reexport!(_jit_pointer_p, pointer_p, ptr: JitPointer; -> bool);
 
-    jit_reexport!(_jit_patch, patch, instr: &JitNode);
-    jit_reexport!(_jit_patch_at, patch_at, instr: &JitNode, target: &JitNode);
-    jit_reexport!(_jit_patch_abs, patch_abs, instr: &JitNode, target: JitPointer);
+    jit_reexport!(_jit_patch, patch, instr: &JitNode<'a>);
+    jit_reexport!(_jit_patch_at, patch_at, instr: &JitNode<'a>, target: &JitNode<'a>);
+    jit_reexport!(_jit_patch_abs, patch_abs, instr: &JitNode<'a>, target: JitPointer);
     jit_reexport!(_jit_realize, realize);
 
     // get_code needs argument mangling that jit_reexport currently does not
@@ -123,9 +123,9 @@ impl<'a> JitState<'a> {
 /// implementations of word-size-dependent aliases
 impl<'a> JitState<'a> {
     #[cfg(target_pointer_width = "64")]
-    jit_alias!(getarg_l => getarg, reg: Reg, node: &JitNode);
+    jit_alias!(getarg_l => getarg, reg: Reg, node: &JitNode<'a>);
     #[cfg(target_pointer_width = "32")]
-    jit_alias!(getarg_i => getarg, reg: Reg, node: &JitNode);
+    jit_alias!(getarg_i => getarg, reg: Reg, node: &JitNode<'a>);
 
     #[cfg(target_pointer_width = "32")]
     jit_alias!(ldr_i => ldr, targ: Reg, src: Reg; -> JitNode);
@@ -207,7 +207,7 @@ impl<'a> JitState<'a> {
     jit_reexport!(_jit_label, label; -> JitNode);
     jit_reexport!(_jit_forward, forward; -> JitNode);
     jit_reexport!(_jit_indirect, indirect; -> JitNode);
-    jit_reexport!(_jit_link, link, node: &JitNode);
+    jit_reexport!(_jit_link, link, node: &JitNode<'a>);
 
     jit_reexport!(_jit_prolog, prolog);
     jit_reexport!(_jit_ellipsis, ellipsis);
@@ -217,18 +217,18 @@ impl<'a> JitState<'a> {
 
     jit_reexport!(_jit_arg, arg; -> JitNode);
 
-    jit_reexport!(_jit_getarg_c, getarg_c, reg: Reg, node: &JitNode);
-    jit_reexport!(_jit_getarg_uc, getarg_uc, reg: Reg, node: &JitNode);
-    jit_reexport!(_jit_getarg_s, getarg_s, reg: Reg, node: &JitNode);
-    jit_reexport!(_jit_getarg_us, getarg_us, reg: Reg, node: &JitNode);
-    jit_reexport!(_jit_getarg_i, getarg_i, reg: Reg, node: &JitNode);
+    jit_reexport!(_jit_getarg_c, getarg_c, reg: Reg, node: &JitNode<'a>);
+    jit_reexport!(_jit_getarg_uc, getarg_uc, reg: Reg, node: &JitNode<'a>);
+    jit_reexport!(_jit_getarg_s, getarg_s, reg: Reg, node: &JitNode<'a>);
+    jit_reexport!(_jit_getarg_us, getarg_us, reg: Reg, node: &JitNode<'a>);
+    jit_reexport!(_jit_getarg_i, getarg_i, reg: Reg, node: &JitNode<'a>);
     #[cfg(target_pointer_width = "64")]
-    jit_reexport!(_jit_getarg_ui, getarg_ui, reg: Reg, node: &JitNode);
+    jit_reexport!(_jit_getarg_ui, getarg_ui, reg: Reg, node: &JitNode<'a>);
     #[cfg(target_pointer_width = "64")]
-    jit_reexport!(_jit_getarg_l, getarg_l, reg: Reg, node: &JitNode);
+    jit_reexport!(_jit_getarg_l, getarg_l, reg: Reg, node: &JitNode<'a>);
 
-    jit_reexport!(_jit_putargr, putargr, reg: Reg, arg: &JitNode);
-    jit_reexport!(_jit_putargi, putargi, imm: JitWord, arg: &JitNode);
+    jit_reexport!(_jit_putargr, putargr, reg: Reg, arg: &JitNode<'a>);
+    jit_reexport!(_jit_putargi, putargi, imm: JitWord, arg: &JitNode<'a>);
 
     jit_reexport!(_jit_va_push, va_push, arg: Reg);
 
@@ -280,9 +280,9 @@ impl<'a> JitState<'a> {
 /// implmentations of 32-bit float instructions
 impl<'a> JitState<'a> {
     jit_reexport!(_jit_arg_f, arg_f; -> JitNode);
-    jit_reexport!(_jit_getarg_f, getarg_f, reg: Reg, arg: &JitNode);
-    jit_reexport!(_jit_putargr_f, putargr_f, reg: Reg, arg: &JitNode);
-    jit_reexport!(_jit_putargi_f, putargi_f, imm: f32, arg: &JitNode);
+    jit_reexport!(_jit_getarg_f, getarg_f, reg: Reg, arg: &JitNode<'a>);
+    jit_reexport!(_jit_putargr_f, putargr_f, reg: Reg, arg: &JitNode<'a>);
+    jit_reexport!(_jit_putargi_f, putargi_f, imm: f32, arg: &JitNode<'a>);
 
     pub fn rsbr_f(&mut self, a: Reg, b: Reg, c: Reg) -> JitNode<'a> {
         self.subr_f(a, c, b)
@@ -298,9 +298,9 @@ impl<'a> JitState<'a> {
 /// implmentations of 64-bit float instructions
 impl<'a> JitState<'a> {
     jit_reexport!(_jit_arg_d, arg_d; -> JitNode);
-    jit_reexport!(_jit_getarg_d, getarg_d, reg: Reg, arg: &JitNode);
-    jit_reexport!(_jit_putargr_d, putargr_d, reg: Reg, arg: &JitNode);
-    jit_reexport!(_jit_putargi_d, putargi_d, imm: f64, arg: &JitNode);
+    jit_reexport!(_jit_getarg_d, getarg_d, reg: Reg, arg: &JitNode<'a>);
+    jit_reexport!(_jit_putargr_d, putargr_d, reg: Reg, arg: &JitNode<'a>);
+    jit_reexport!(_jit_putargi_d, putargi_d, imm: f64, arg: &JitNode<'a>);
 
     pub fn rsbr_d(&mut self, a: Reg, b: Reg, c: Reg) -> JitNode<'a> {
         self.subr_d(a, c, b)

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -220,6 +220,65 @@ impl<'a> JitState<'a> {
     jit_reexport!(print);
 }
 
+/// implementations of word-size-dependent aliases
+impl<'a> JitState<'a> {
+    #[cfg(target_pointer_width = "64")]
+    jit_alias!(getarg_l => getarg, reg: Reg, node: &JitNode);
+    #[cfg(target_pointer_width = "32")]
+    jit_alias!(getarg_i => getarg, reg: Reg, node: &JitNode);
+
+    #[cfg(target_pointer_width = "32")]
+    jit_alias!(ldr_i => ldr, targ: Reg, src: Reg; -> JitNode);
+    #[cfg(target_pointer_width = "32")]
+    jit_alias!(ldi_i => ldi, targ: Reg, src: JitPointer; -> JitNode);
+    #[cfg(target_pointer_width = "64")]
+    jit_alias!(ldr_l => ldr, targ: Reg, src: Reg; -> JitNode);
+    #[cfg(target_pointer_width = "64")]
+    jit_alias!(ldi_l => ldi, targ: Reg, src: JitPointer; -> JitNode);
+
+    #[cfg(target_pointer_width = "32")]
+    jit_alias!(ldxr_i => ldxr, targ: Reg, a: Reg, b: Reg; -> JitNode);
+    #[cfg(target_pointer_width = "32")]
+    jit_alias!(ldxi_i => ldxi, targ: Reg, src: Reg, off: JitWord; -> JitNode);
+    #[cfg(target_pointer_width = "64")]
+    jit_alias!(ldxr_l => ldxr, targ: Reg, a: Reg, b: Reg; -> JitNode);
+    #[cfg(target_pointer_width = "64")]
+    jit_alias!(ldxi_l => ldxi, targ: Reg, src: Reg, off: JitWord; -> JitNode);
+
+    #[cfg(target_pointer_width = "32")]
+    jit_alias!(str_i => str, targ: Reg, src: Reg; -> JitNode);
+    #[cfg(target_pointer_width = "32")]
+    jit_alias!(sti_i => sti, targ: JitPointer, src: Reg; -> JitNode);
+    #[cfg(target_pointer_width = "64")]
+    jit_alias!(str_l => str, targ: Reg, src: Reg; -> JitNode);
+    #[cfg(target_pointer_width = "64")]
+    jit_alias!(sti_i => sti, targ: JitPointer, src: Reg; -> JitNode);
+
+    #[cfg(target_pointer_width = "32")]
+    jit_alias!(stxr_i => stxr, off: Reg, targ: Reg, src: Reg; -> JitNode);
+    #[cfg(target_pointer_width = "32")]
+    jit_alias!(stxi_i => stxi, off: JitWord, targ: Reg, src: Reg; -> JitNode);
+    #[cfg(target_pointer_width = "64")]
+    jit_alias!(stxr_l => stxr, off: Reg, targ: Reg, src: Reg; -> JitNode);
+    #[cfg(target_pointer_width = "64")]
+    jit_alias!(stxi_l => stxi, off: JitWord, targ: Reg, src: Reg; -> JitNode);
+
+    #[cfg(target_pointer_width = "32")]
+    jit_alias!(retval_i => retval, rv: Reg);
+    #[cfg(target_pointer_width = "64")]
+    jit_alias!(retval_l => retval, rv: Reg);
+
+    #[cfg(target_pointer_width = "32")]
+    jit_alias!(truncr_f_i => truncr_f, int: Reg, float: Reg; -> JitNode);
+    #[cfg(target_pointer_width = "64")]
+    jit_alias!(truncr_f_l => truncr_f, int: Reg, float: Reg; -> JitNode);
+
+    #[cfg(target_pointer_width = "32")]
+    jit_alias!(truncr_d_i => truncr_d, int: Reg, float: Reg; -> JitNode);
+    #[cfg(target_pointer_width = "64")]
+    jit_alias!(truncr_d_l => truncr_d, int: Reg, float: Reg; -> JitNode);
+}
+
 /// implmentations of general instructions
 impl<'a> JitState<'a> {
     jit_impl!(live, w);
@@ -269,10 +328,6 @@ impl<'a> JitState<'a> {
     jit_reexport!(getarg_ui, reg: Reg, node: &JitNode);
     #[cfg(target_pointer_width = "64")]
     jit_reexport!(getarg_l, reg: Reg, node: &JitNode);
-    #[cfg(target_pointer_width = "64")]
-    jit_alias!(getarg_l => getarg, reg: Reg, node: &JitNode);
-    #[cfg(target_pointer_width = "32")]
-    jit_alias!(getarg_i => getarg, reg: Reg, node: &JitNode);
 
     jit_reexport!(putargr, reg: Reg, arg: &JitNode);
     jit_reexport!(putargi, imm: JitWord, arg: &JitNode);
@@ -403,14 +458,6 @@ impl<'a> JitState<'a> {
     jit_impl!(ldr_l, ww);
     #[cfg(target_pointer_width = "64")]
     jit_impl!(ldi_l, i_wp);
-    #[cfg(target_pointer_width = "32")]
-    jit_alias!(ldr_i => ldr, targ: Reg, src: Reg; -> JitNode);
-    #[cfg(target_pointer_width = "32")]
-    jit_alias!(ldi_i => ldi, targ: Reg, src: JitPointer; -> JitNode);
-    #[cfg(target_pointer_width = "64")]
-    jit_alias!(ldr_l => ldr, targ: Reg, src: Reg; -> JitNode);
-    #[cfg(target_pointer_width = "64")]
-    jit_alias!(ldi_l => ldi, targ: Reg, src: JitPointer; -> JitNode);
 
     jit_impl!(ldxr_c, www);
     jit_impl!(ldxi_c, i_www);
@@ -430,14 +477,6 @@ impl<'a> JitState<'a> {
     jit_impl!(ldxr_l, www);
     #[cfg(target_pointer_width = "64")]
     jit_impl!(ldxi_l, i_www);
-    #[cfg(target_pointer_width = "32")]
-    jit_alias!(ldxr_i => ldxr, targ: Reg, a: Reg, b: Reg; -> JitNode);
-    #[cfg(target_pointer_width = "32")]
-    jit_alias!(ldxi_i => ldxi, targ: Reg, src: Reg, off: JitWord; -> JitNode);
-    #[cfg(target_pointer_width = "64")]
-    jit_alias!(ldxr_l => ldxr, targ: Reg, a: Reg, b: Reg; -> JitNode);
-    #[cfg(target_pointer_width = "64")]
-    jit_alias!(ldxi_l => ldxi, targ: Reg, src: Reg, off: JitWord; -> JitNode);
 
     jit_store!(str_c, ww);
     jit_store!(sti_c, i_pw);
@@ -449,14 +488,6 @@ impl<'a> JitState<'a> {
     jit_store!(str_l, ww);
     #[cfg(target_pointer_width = "64")]
     jit_store!(sti_l, i_pw);
-    #[cfg(target_pointer_width = "32")]
-    jit_alias!(str_i => str, targ: Reg, src: Reg; -> JitNode);
-    #[cfg(target_pointer_width = "32")]
-    jit_alias!(sti_i => sti, targ: JitPointer, src: Reg; -> JitNode);
-    #[cfg(target_pointer_width = "64")]
-    jit_alias!(str_l => str, targ: Reg, src: Reg; -> JitNode);
-    #[cfg(target_pointer_width = "64")]
-    jit_alias!(sti_i => sti, targ: JitPointer, src: Reg; -> JitNode);
 
     jit_store!(stxr_c, www);
     jit_store!(stxi_c, i_www);
@@ -468,14 +499,6 @@ impl<'a> JitState<'a> {
     jit_store!(stxr_l, www);
     #[cfg(target_pointer_width = "64")]
     jit_store!(stxi_l, i_www);
-    #[cfg(target_pointer_width = "32")]
-    jit_alias!(stxr_i => stxr, off: Reg, targ: Reg, src: Reg; -> JitNode);
-    #[cfg(target_pointer_width = "32")]
-    jit_alias!(stxi_i => stxi, off: JitWord, targ: Reg, src: Reg; -> JitNode);
-    #[cfg(target_pointer_width = "64")]
-    jit_alias!(stxr_l => stxr, off: Reg, targ: Reg, src: Reg; -> JitNode);
-    #[cfg(target_pointer_width = "64")]
-    jit_alias!(stxi_l => stxi, off: JitWord, targ: Reg, src: Reg; -> JitNode);
 
     jit_branch!(bltr, r);
     jit_branch!(blti, i);
@@ -567,10 +590,6 @@ impl<'a> JitState<'a> {
     jit_reexport!(retval_ui, rv: Reg);
     #[cfg(target_pointer_width = "64")]
     jit_reexport!(retval_l, rv: Reg);
-    #[cfg(target_pointer_width = "32")]
-    jit_alias!(retval_i => retval, rv: Reg);
-    #[cfg(target_pointer_width = "64")]
-    jit_alias!(retval_l => retval, rv: Reg);
     jit_reexport!(epilog);
 
     jit_reexport!(frame, size: i32);
@@ -634,10 +653,6 @@ impl<'a> JitState<'a> {
     jit_impl!(truncr_f_i, ww);
     #[cfg(target_pointer_width = "64")]
     jit_impl!(truncr_f_l, ww);
-    #[cfg(target_pointer_width = "32")]
-    jit_alias!(truncr_f_i => truncr_f, int: Reg, float: Reg; -> JitNode);
-    #[cfg(target_pointer_width = "64")]
-    jit_alias!(truncr_f_l => truncr_f, int: Reg, float: Reg; -> JitNode);
 
     jit_impl!(extr_f, ww);
     jit_impl!(extr_d_f, ww);
@@ -747,10 +762,6 @@ impl<'a> JitState<'a> {
     jit_impl!(truncr_d_i, ww);
     #[cfg(target_pointer_width = "64")]
     jit_impl!(truncr_d_l, ww);
-    #[cfg(target_pointer_width = "32")]
-    jit_alias!(truncr_d_i => truncr_d, int: Reg, float: Reg; -> JitNode);
-    #[cfg(target_pointer_width = "64")]
-    jit_alias!(truncr_d_l => truncr_d, int: Reg, float: Reg; -> JitNode);
 
     jit_impl!(extr_d, ww);
     jit_impl!(extr_f_d, ww);

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -92,7 +92,7 @@ impl<'a> JitState<'a> {
         unsafe { bindings::_jit_get_code(self.state, pointer_from(code_size)) }
     }
 
-    jit_reexport!(_jit_set_code, set_code, buf: JitPointer, size: JitWord; -> ());
+    jit_reexport!(_jit_set_code, set_code, buf: JitPointer, size: JitWord);
 
     // get_data needs argument mangling that jit_reexport currently does not
     // provide
@@ -110,7 +110,7 @@ impl<'a> JitState<'a> {
         }
     }
 
-    jit_reexport!(_jit_set_data, set_data, buf: JitPointer, data_size: JitWord, flags: JitWord; -> ());
+    jit_reexport!(_jit_set_data, set_data, buf: JitPointer, data_size: JitWord, flags: JitWord);
 
     jit_reexport!(_jit_print, print);
 }

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -323,6 +323,8 @@ macro_rules! private_make_func {
     };
 }
 
+/// Provides a compact way to call a tt-call macro from a pattern matched from
+/// jit_entry.
 macro_rules! mm {
     ( ( $entry:ident ( $( $inarg:ident ),* ) $root:ident ) => ( $( $types:ty ),* ) => ( $( $outarg:ident ),* ) ) => {
         make_func! {
@@ -435,6 +437,8 @@ fn trivial_invocation() {
     impl MyDefault for Reg        { fn default() -> Self { Reg::R(0)          } }
     impl MyDefault for JitPointer { fn default() -> Self { crate::types::NULL } }
 
+    /// Calls the function represented by each `jit_entry` that corresponds to
+    /// a `jit_new_node_*` call.
     macro_rules! mm {
         ( ( $entry:ident ( $( $inarg:ident ),* ) $root:ident ) => ( $( $types:ty ),* ) => ( $( $outarg:ident ),* ) ) => {
             {
@@ -445,6 +449,8 @@ fn trivial_invocation() {
         };
     }
 
+    /// Calls the function represented by each `jit_entry` that does *not*
+    /// correspond to a `jit_new_node_*` call.
     macro_rules! jit_entry_non_node {
         {
             $caller:tt

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -21,8 +21,8 @@ impl<'a> Drop for JitState<'a> {
 }
 
 macro_rules! jit_reexport {
-    ( $orig:ident, $fn:ident $(, $arg:ident : $typ:ty )*; -> JitNode) => {
-        pub fn $fn(&mut self $(, $arg: $typ )*) -> JitNode<'a> {
+    ( $orig:ident, $fn:ident $(, $arg:ident : $typ:ty )*; -> JitNode<$life:lifetime>) => {
+        pub fn $fn(&mut self $(, $arg: $typ )*) -> JitNode<$life> {
             JitNode{
                 node: unsafe { bindings::$orig(self.state $(, $arg.to_ffi())*) },
                 phantom: std::marker::PhantomData,
@@ -199,9 +199,9 @@ impl<'a> JitState<'a> {
         }
     }
 
-    jit_reexport!(_jit_label, label; -> JitNode);
-    jit_reexport!(_jit_forward, forward; -> JitNode);
-    jit_reexport!(_jit_indirect, indirect; -> JitNode);
+    jit_reexport!(_jit_label, label; -> JitNode<'a>);
+    jit_reexport!(_jit_forward, forward; -> JitNode<'a>);
+    jit_reexport!(_jit_indirect, indirect; -> JitNode<'a>);
     jit_reexport!(_jit_link, link, node: &JitNode<'a>);
 
     jit_reexport!(_jit_prolog, prolog);
@@ -210,7 +210,7 @@ impl<'a> JitState<'a> {
     jit_reexport!(_jit_allocai, allocai, size: i32; -> i32);
     jit_reexport!(_jit_allocar, allocar, off: Reg, size: Reg);
 
-    jit_reexport!(_jit_arg, arg; -> JitNode);
+    jit_reexport!(_jit_arg, arg; -> JitNode<'a>);
 
     jit_reexport!(_jit_getarg_c, getarg_c, reg: Reg, node: &JitNode<'a>);
     jit_reexport!(_jit_getarg_uc, getarg_uc, reg: Reg, node: &JitNode<'a>);
@@ -253,7 +253,7 @@ impl<'a> JitState<'a> {
     jit_reexport!(_jit_pushargr, pushargr, arg: Reg);
     jit_reexport!(_jit_pushargi, pushargi, arg: JitWord);
     jit_reexport!(_jit_finishr, finishr, arg: Reg);
-    jit_reexport!(_jit_finishi, finishi, arg: JitPointer; -> JitNode);
+    jit_reexport!(_jit_finishi, finishi, arg: JitPointer; -> JitNode<'a>);
     jit_reexport!(_jit_ret, ret);
     jit_reexport!(_jit_retr, retr, rv: Reg);
     jit_reexport!(_jit_reti, reti, rv: JitWord);
@@ -274,7 +274,7 @@ impl<'a> JitState<'a> {
 
 /// implmentations of 32-bit float instructions
 impl<'a> JitState<'a> {
-    jit_reexport!(_jit_arg_f, arg_f; -> JitNode);
+    jit_reexport!(_jit_arg_f, arg_f; -> JitNode<'a>);
     jit_reexport!(_jit_getarg_f, getarg_f, reg: Reg, arg: &JitNode<'a>);
     jit_reexport!(_jit_putargr_f, putargr_f, reg: Reg, arg: &JitNode<'a>);
     jit_reexport!(_jit_putargi_f, putargi_f, imm: f32, arg: &JitNode<'a>);
@@ -292,7 +292,7 @@ impl<'a> JitState<'a> {
 
 /// implmentations of 64-bit float instructions
 impl<'a> JitState<'a> {
-    jit_reexport!(_jit_arg_d, arg_d; -> JitNode);
+    jit_reexport!(_jit_arg_d, arg_d; -> JitNode<'a>);
     jit_reexport!(_jit_getarg_d, getarg_d, reg: Reg, arg: &JitNode<'a>);
     jit_reexport!(_jit_putargr_d, putargr_d, reg: Reg, arg: &JitNode<'a>);
     jit_reexport!(_jit_putargi_d, putargi_d, imm: f64, arg: &JitNode<'a>);

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -220,7 +220,8 @@ macro_rules! make_func {
     };
 }
 
-/// Defines an associated function for `JitState` for each `jit_entry`.
+/// Defines an inherent method for `JitState` for each `jit_entry` that
+/// corresponds to a `jit_new_node_*` call.
 macro_rules! jit_filtered {
     {
         $caller:tt
@@ -381,6 +382,8 @@ fn trivial_invocation() {
 
     impl MyDefault for jit_pointer_t { fn default() -> Self { crate::types::NULL } }
 
+    /// Calls the function represented by each `jit_entry` that corresponds to
+    /// a `jit_new_node_*` call.
     macro_rules! jit_filtered {
         {
             $caller:tt

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -66,6 +66,30 @@ macro_rules! jit_signature {
     { $c:tt suffix = [{ jit_new_node_www }] } => { tt_return!{ $c parmtypes = [{ jit_word_t, jit_word_t, jit_word_t               }] } };
 }
 
+macro_rules! is_new_node_func {
+    { $caller:tt input = [{ jit_new_node     }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_d   }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_dp  }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_f   }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_fp  }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_p   }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_pw  }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_pwd }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_pwf }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_pww }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_qww }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_w   }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_wd  }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_wf  }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_wp  }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_ww  }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_wwd }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_wwf }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_www }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+
+    { $caller:tt input = [{ $( $any:tt )*    }] } => { tt_return!{ $caller is_new_node_func = [{ false }] } };
+}
+
 /// Calls `zip_params` after dropping zero or more tokens from each list.
 /// <sup>**[tt-call]**</sup>
 ///

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -286,6 +286,12 @@ macro_rules! jit_filtered {
     };
 }
 
+macro_rules! jit_entry_non_node {
+    { $( $tokens:tt )* } => {
+        // Ignore these for now.
+    };
+}
+
 macro_rules! jit_entry {
     {   $entry:ident $inargs:tt
             => $root:ident
@@ -318,10 +324,29 @@ macro_rules! jit_entry {
                         }
                     }]
                     false = [{
-                        /* ignored for now */
+                        tt_call! {
+                            macro = [{ jit_entry_non_node }]
+                            decl = [{ $entry $inargs }]
+                            root = [{ $root }]
+                            parts = [{ $( $parts )* }]
+                            invokes = [{ $invokes $outargs }]
+                        }
                     }]
                 }
             }]
+        }
+    };
+    {   $entry:ident $inargs:tt
+            => $root:ident
+            => [ $( $parts:ident ),* ]
+            => $( $other:tt )*
+    } => {
+        tt_call! {
+            macro = [{ jit_entry_non_node }]
+            decl = [{ $entry $inargs }]
+            root = [{ $root }]
+            parts = [{ $( $parts )* }]
+            invokes = [{ $( $other )* }]
         }
     };
 }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -10,11 +10,11 @@
 //! The Rust APIs provided here look like this:
 //! ```ignore
 //! impl<'j> JitState<'j> {
-//!     pub unsafe fn jit_absr_d(&mut self, u: jit_word_t, v: jit_word_t) -> JitNode<'j> {
+//!     pub(crate) unsafe fn jit_absr_d(&mut self, u: jit_word_t, v: jit_word_t) -> JitNode<'j> {
 //!         self.jit_new_node_ww(jit_code_t::jit_code_absr_d, u, v)
 //!     }
 //!
-//!     pub unsafe fn jit_new_node_ww(
+//!     pub(crate) unsafe fn jit_new_node_ww(
 //!         &mut self,
 //!         c: jit_code_t,
 //!         u: jit_word_t,
@@ -177,7 +177,7 @@ macro_rules! zip_params {
     };
 }
 
-/// Defines a `pub unsafe fn` with a given name, parameters, and body.
+/// Defines an `pub(crate) unsafe fn` with a given name, parameters, and body.
 /// <sup>**[tt-call]**</sup>
 macro_rules! private_make_func {
     {
@@ -188,13 +188,14 @@ macro_rules! private_make_func {
         zipped = [{ $( $params:tt )* }]
     } => {
         #[allow(clippy::missing_safety_doc)]
-        pub unsafe fn $fname $( < $( $life ),+ > )? ( $( $parmhead )* $( $params )* ) -> $rettype {
+        #[allow(dead_code)] // Not all generated functions will be used.
+        pub(crate) unsafe fn $fname $( < $( $life ),+ > )? ( $( $parmhead )* $( $params )* ) -> $rettype {
             $( $body )*
         }
     };
 }
 
-/// Defines a `pub unsafe fn` with a given name, parameters, and body.
+/// Defines a `pub(crate) unsafe fn` with a given name, parameters, and body.
 /// <sup>**[tt-call]**</sup>
 macro_rules! make_func {
     {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -292,12 +292,36 @@ macro_rules! jit_entry {
             => [ $( $parts:ident ),* ]
             => $invokes:ident $outargs:tt
     } => {
-        tt_call! {
-            macro = [{ jit_filtered }]
-            decl = [{ $entry $inargs }]
-            root = [{ $root }]
-            parts = [{ $( $parts )* }]
-            invokes = [{ $invokes $outargs }]
+        tt_if! {
+            condition = [{ is_new_node_func }]
+            input = [{ $invokes }]
+            true = [{
+                tt_call! {
+                    macro = [{ jit_filtered }]
+                    decl = [{ $entry $inargs }]
+                    root = [{ $root }]
+                    parts = [{ $( $parts )* }]
+                    invokes = [{ $invokes $outargs }]
+                }
+            }]
+            false = [{
+                tt_if! {
+                    condition = [{ is_new_node_func }]
+                    input = [{ $entry }]
+                    true = [{
+                        tt_call! {
+                            macro = [{ jit_filtered }]
+                            decl = [{ $entry $inargs }]
+                            root = [{ $root }]
+                            parts = [{ $( $parts )* }]
+                            invokes = [{ $invokes $outargs }]
+                        }
+                    }]
+                    false = [{
+                        /* ignored for now */
+                    }]
+                }
+            }]
         }
     };
 }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -289,6 +289,22 @@ macro_rules! jit_filtered {
 }
 
 macro_rules! jit_entry_non_node {
+    {
+        $caller:tt
+        decl = [{ $entry:ident( $( $inarg:ident ),* ) }]
+        root = [{ destroy_state }]
+        parts = [{ $stem:ident $( $suffix:ident )* }]
+        invokes = [{ $invokes:ident( _jit $( , $outarg:ident )* ) }]
+    } => {
+        make_func! {
+            func = [{ $entry }]
+            body = [{ $invokes( self.state, $( $outarg ),* ) }]
+            rettype = [{ () }]
+            parmhead = [{ self, }] // Takes `self` by move, NOT by reference
+            parmnames = [{ }]
+            parmtypes = [{ }]
+        }
+    };
     { $( $tokens:tt )* } => {
         // Ignore these for now.
     };
@@ -407,6 +423,12 @@ fn trivial_invocation() {
                 $( let $inarg = MyDefault::default(); )*
                 let _ = $crate::Jit::new().new_state().$entry( $( $inarg ),* );
             }
+        };
+    }
+
+    macro_rules! jit_entry_non_node {
+        { $( $tokens:tt )* } => {
+            // Ignore these for now.
         };
     }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -367,6 +367,7 @@ include!(concat!(env!("OUT_DIR"), "/entries.rs"));
 #[allow(unused_variables)]
 fn trivial_invocation() {
     let mut new_node_count = 0;
+    let mut entry_count = 0;
 
     trait MyDefault { fn default() -> Self; }
 
@@ -399,6 +400,7 @@ fn trivial_invocation() {
             invokes = [{ $invokes:ident( $enum:ident $( , $outarg:ident )* ) }]
         } => {
             {
+                entry_count += 1;
                 $( let $inarg = MyDefault::default(); )*
                 let _ = $crate::Jit::new().new_state().$entry( $( $inarg ),* );
             }
@@ -414,5 +416,6 @@ fn trivial_invocation() {
     include!{ concat!(env!("OUT_DIR"), "/entries.rs") }
 
     assert_eq!(new_node_count, 19, "an unexpected number of jit_new_node* entry points were seen");
+    assert!(entry_count > 320, "an unexpected number of jit_new_node* callers were seen");
 }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -366,6 +366,8 @@ include!(concat!(env!("OUT_DIR"), "/entries.rs"));
 #[allow(unreachable_code)]
 #[allow(unused_variables)]
 fn trivial_invocation() {
+    let mut new_node_count = 0;
+
     trait MyDefault { fn default() -> Self; }
 
     impl MyDefault for jit_word_t    { fn default() -> Self { Default::default() } }
@@ -386,6 +388,7 @@ fn trivial_invocation() {
             parts = [{ new_node $( $suffix:ident )* }]
             invokes = [{ $invokes:ident( $enum:ident $( , $outarg:ident )* ) }]
         } => {
+            new_node_count += 1;
             /* skip */
         };
         {
@@ -409,5 +412,7 @@ fn trivial_invocation() {
     }
 
     include!{ concat!(env!("OUT_DIR"), "/entries.rs") }
+
+    assert_eq!(new_node_count, 19, "an unexpected number of jit_new_node* entry points were seen");
 }
 


### PR DESCRIPTION
# Goals
1. Demonstrate improved *predictability* of the Rust interface (how closely the Rust interface follows the C interface)
1. Reduce the risk of failing to implement an entry point from the C library
1. Increase the likelihood that any API changes or additions in future GNU lightning versions will either be supported automatically, or manifested as build failures in `lightning-sys`, as opposed to being hidden

# Means
Using the foundation laid in #32, the current PR implements a pattern-matching paradigm to generate public entry point wrappers.
- Every `jit_` macro exposed by GNU lightning will either match a pattern (and have a generated entry point) or fail to match (and cause a build error).
- This contrasts with the previous paradigm where an entry points was maintained manually, which contributed to causing some entry points to be missed (#34, #35, #37, #42).

# Gains
1. The Rust interface hews more closely to the C interface, reducing surprise for the user.
1. The risk of some kinds of bugs may be reduced, by decreasing the number of failure modes.
1. Self-checking is improved, since the new mechanism generates simple test cases to demonstrate that that all `jit_`-macro entry points advertised by GNU lightning's `lightning.h` exist, and (in most cases) that the entry points can be called with zeroed parameters without crashing.
1. The net volume of code to maintain (even including what was introduced in #32) is decreased somewhat, after accounting for the generated tests that did not previously exist.

# Costs
The new implementation (including work done in #32) carries a significant burden of complexity, especially in macros. The use of [`tt-call`](https://crates.io/crates/tt-call) makes the macros more composable and understandable individually, but contributes to the verbosity of the macro implementation.