### PR TITLE
Regularize interface naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ js.addi(Reg::R(0), Reg::R(0), 1);
 js.retr(Reg::R(0));
 
 let incr = unsafe { js.emit::<extern fn(JitWord) -> JitWord>() };
-js.clear();
+js.clear_state();
 
 assert_eq!(incr(5), 6);
 assert_eq!(incr(6), 7);
@@ -64,7 +64,7 @@ fn main() {
     let my_function = unsafe{ js.emit::<extern fn(JitWord)>() };
     /* call the generated code, passing its size as argument */
     my_function((js.address(&end) as u64 - js.address(&start) as u64).try_into().unwrap());
-    js.clear();
+    js.clear_state();
 
     // TODO: dissasembly has not been implemented yet
     // js.dissasemble();
@@ -107,7 +107,7 @@ fn main() {
                 js.epilog();
 
     let fib = unsafe{ js.emit::<extern fn(JitWord) -> JitWord>() };
-    js.clear();
+    js.clear_state();
 
     println!("fib({})={}", 32, fib(32));
     assert_eq!(0, fib(0));
@@ -159,7 +159,7 @@ fn main() {
                 js.retr(Reg::R(0));
 
     let factorial = unsafe{ js.emit::<extern fn(JitWord) -> JitWord>() };
-    js.clear();
+    js.clear_state();
 
     println!("factorial({}) = {}", 5, factorial(5));
 }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ js.getarg(Reg::R(0), &inarg);
 js.addi(Reg::R(0), Reg::R(0), 1);
 js.retr(Reg::R(0));
 
-let incr = unsafe { js.emit::<extern fn(JitWord) -> JitWord>() };
+let incr = unsafe { js.cast_emit::<extern fn(JitWord) -> JitWord>() };
 js.clear_state();
 
 assert_eq!(incr(5), 6);
@@ -61,7 +61,7 @@ fn main() {
     js.epilog();
     let end = js.note(file!(), line!());
 
-    let my_function = unsafe{ js.emit::<extern fn(JitWord)>() };
+    let my_function = unsafe{ js.cast_emit::<extern fn(JitWord)>() };
     /* call the generated code, passing its size as argument */
     my_function((js.address(&end) as u64 - js.address(&start) as u64).try_into().unwrap());
     js.clear_state();
@@ -106,7 +106,7 @@ fn main() {
                 js.retr(Reg::R(0));
                 js.epilog();
 
-    let fib = unsafe{ js.emit::<extern fn(JitWord) -> JitWord>() };
+    let fib = unsafe{ js.cast_emit::<extern fn(JitWord) -> JitWord>() };
     js.clear_state();
 
     println!("fib({})={}", 32, fib(32));
@@ -158,7 +158,7 @@ fn main() {
                 js.patch(&f_out);
                 js.retr(Reg::R(0));
 
-    let factorial = unsafe{ js.emit::<extern fn(JitWord) -> JitWord>() };
+    let factorial = unsafe{ js.cast_emit::<extern fn(JitWord) -> JitWord>() };
     js.clear_state();
 
     println!("factorial({}) = {}", 5, factorial(5));

--- a/examples/fact.rs
+++ b/examples/fact.rs
@@ -49,7 +49,7 @@ fn main() {
 
     let factorial = unsafe{ js.emit::<extern fn(JitWord) -> JitWord>() };
     /* no need to query information about resolved addresses */
-    js.clear();
+    js.clear_state();
 
     let arg = std::env::args().nth(1).map(|x| x.parse().unwrap_or(0)).unwrap_or(5);
 

--- a/examples/fact.rs
+++ b/examples/fact.rs
@@ -47,7 +47,7 @@ fn main() {
     js.patch(&fact_out);
     js.retr(JIT_R0);                    /* Return the accumulator */
 
-    let factorial = unsafe{ js.emit::<extern fn(JitWord) -> JitWord>() };
+    let factorial = unsafe{ js.cast_emit::<extern fn(JitWord) -> JitWord>() };
     /* no need to query information about resolved addresses */
     js.clear_state();
 

--- a/examples/ifib.rs
+++ b/examples/ifib.rs
@@ -34,7 +34,7 @@ fn main() {
     js.patch(&zero);                                    /* patch forward jump */
                 js.retr     (JIT_R0);
 
-    let fib = unsafe{ js.emit::<extern fn(JitWord) -> JitWord>() };
+    let fib = unsafe{ js.cast_emit::<extern fn(JitWord) -> JitWord>() };
     js.clear_state();
 
     println!("fib({}) = {}", 36, fib(36));

--- a/examples/ifib.rs
+++ b/examples/ifib.rs
@@ -35,7 +35,7 @@ fn main() {
                 js.retr     (JIT_R0);
 
     let fib = unsafe{ js.emit::<extern fn(JitWord) -> JitWord>() };
-    js.clear();
+    js.clear_state();
 
     println!("fib({}) = {}", 36, fib(36));
 }

--- a/examples/incr.rs
+++ b/examples/incr.rs
@@ -15,7 +15,7 @@ fn main() {
     js.addi(JIT_R0, JIT_R0, 1);
     js.retr(JIT_R0);
 
-    let incr = unsafe{ js.emit::<extern fn(JitWord) -> JitWord>() };
+    let incr = unsafe{ js.cast_emit::<extern fn(JitWord) -> JitWord>() };
     js.clear_state();
 
     /* call the generated code, passing 5 as an argument */

--- a/examples/incr.rs
+++ b/examples/incr.rs
@@ -16,7 +16,7 @@ fn main() {
     js.retr(JIT_R0);
 
     let incr = unsafe{ js.emit::<extern fn(JitWord) -> JitWord>() };
-    js.clear();
+    js.clear_state();
 
     /* call the generated code, passing 5 as an argument */
     println!("{} + 1 = {}", 5, incr(5));

--- a/examples/printf.rs
+++ b/examples/printf.rs
@@ -32,7 +32,7 @@ fn main() {
 
     /* call the generated code, passing its size as argument */
     myFunction((js.address(&end) as usize - js.address(&start) as usize).try_into().unwrap());
-    js.clear();
+    js.clear_state();
 
     // js.disassemble(); // TODO support disassembly
 }

--- a/examples/printf.rs
+++ b/examples/printf.rs
@@ -28,7 +28,7 @@ fn main() {
     js.epilog();
     let end = js.note(Some(file!()), line!());
 
-    let myFunction = unsafe{ js.emit::<extern fn(JitWord)>() };
+    let myFunction = unsafe{ js.cast_emit::<extern fn(JitWord)>() };
 
     /* call the generated code, passing its size as argument */
     myFunction((js.address(&end) as usize - js.address(&start) as usize).try_into().unwrap());

--- a/examples/rfib.rs
+++ b/examples/rfib.rs
@@ -39,7 +39,7 @@ fn main() {
                 js.retr(JIT_R0);
 
     let fib = unsafe{ js.emit::<extern fn(JitWord) -> JitWord>() };
-    js.clear();
+    js.clear_state();
 
     println!("fib({}) = {}", 32, fib(32));
 }

--- a/examples/rfib.rs
+++ b/examples/rfib.rs
@@ -38,7 +38,7 @@ fn main() {
     js.patch(&zero);                                    /* patch jump */
                 js.retr(JIT_R0);
 
-    let fib = unsafe{ js.emit::<extern fn(JitWord) -> JitWord>() };
+    let fib = unsafe{ js.cast_emit::<extern fn(JitWord) -> JitWord>() };
     js.clear_state();
 
     println!("fib({}) = {}", 32, fib(32));

--- a/examples/rpn.rs
+++ b/examples/rpn.rs
@@ -80,7 +80,7 @@ fn main() {
     let c2f = unsafe { to_func::<_, c_int>(c2f) };
     let f2c = js.address(&nf);
     let f2c = unsafe { to_func::<_, c_int>(f2c) };
-    js.clear();
+    js.clear_state();
 
     print!("\nC:");
     for i in 0..=10 { print!("{:3} ", i * 10); }

--- a/examples/rpn.rs
+++ b/examples/rpn.rs
@@ -70,7 +70,7 @@ fn main() {
     let nc = compile_rpn(&mut js, "32x9*5/+");
     let nf = compile_rpn(&mut js, "x32-5*9/");
 
-    let _ = js.raw_emit();
+    let _ = js.emit();
 
     unsafe fn to_func<T,R>(ptr: JitPointer) -> extern "C" fn(T) -> R {
         *(&ptr as *const *mut core::ffi::c_void as *const extern "C" fn(T) -> R)

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -176,11 +176,7 @@ impl<'a> JitState<'a> {
         *(&self.emit() as *const *mut core::ffi::c_void as *const T)
     }
 
-    pub fn emit(&mut self) -> JitPointer {
-        unsafe {
-            bindings::_jit_emit(self.state)
-        }
-    }
+    jit_reexport!(emit; -> JitPointer);
 
     jit_reexport!(address, node: &JitNode; -> JitPointer);
 

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -172,11 +172,11 @@ impl<'a> JitState<'a> {
 
     // there is no way to require a function type in a trait bound
     // without specifying the number of arguments
-    pub unsafe fn emit<T: Copy>(&mut self) -> T {
+    pub unsafe fn cast_emit<T: Copy>(&mut self) -> T {
         *(&bindings::_jit_emit(self.state) as *const *mut core::ffi::c_void as *const T)
     }
 
-    pub fn raw_emit(&mut self) -> JitPointer {
+    pub fn emit(&mut self) -> JitPointer {
         unsafe {
             bindings::_jit_emit(self.state)
         }

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -164,7 +164,7 @@ macro_rules! jit_alias {
 
 /// `JitState` utility methods
 impl<'a> JitState<'a> {
-    pub fn clear(&mut self) {
+    pub fn clear_state(&mut self) {
         unsafe {
             bindings::_jit_clear_state(self.state);
         }

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -173,7 +173,7 @@ impl<'a> JitState<'a> {
     // there is no way to require a function type in a trait bound
     // without specifying the number of arguments
     pub unsafe fn cast_emit<T: Copy>(&mut self) -> T {
-        *(&bindings::_jit_emit(self.state) as *const *mut core::ffi::c_void as *const T)
+        *(&self.emit() as *const *mut core::ffi::c_void as *const T)
     }
 
     pub fn emit(&mut self) -> JitPointer {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! js.retr(Reg::R(0));
 //!
 //! let incr = unsafe { js.emit::<extern fn(JitWord) -> JitWord>() };
-//! js.clear();
+//! js.clear_state();
 //!
 //! assert_eq!(incr(5), 6);
 //! assert_eq!(incr(6), 7);
@@ -53,7 +53,7 @@
 //!     let my_function = unsafe{ js.emit::<extern fn(JitWord)>() };
 //!     /* call the generated code, passing its size as argument */
 //!     my_function((js.address(&end) as u64 - js.address(&start) as u64).try_into().unwrap());
-//!     js.clear();
+//!     js.clear_state();
 //!
 //!     // TODO: dissasembly has not been implemented yet
 //!     // js.dissasemble();
@@ -97,7 +97,7 @@
 //!                 js.epilog();
 //!
 //!     let fib = unsafe{ js.emit::<extern fn(JitWord) -> JitWord>() };
-//!     js.clear();
+//!     js.clear_state();
 //!
 //!     println!("fib({})={}", 32, fib(32));
 //!     assert_eq!(0, fib(0));
@@ -149,7 +149,7 @@
 //!                 js.retr(Reg::R(0));
 //!
 //!     let factorial = unsafe{ js.emit::<extern fn(JitWord) -> JitWord>() };
-//!     js.clear();
+//!     js.clear_state();
 //!
 //!     println!("factorial({}) = {}", 5, factorial(5));
 //!     assert_eq!(1, factorial(1));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! js.addi(Reg::R(0), Reg::R(0), 1);
 //! js.retr(Reg::R(0));
 //!
-//! let incr = unsafe { js.emit::<extern fn(JitWord) -> JitWord>() };
+//! let incr = unsafe { js.cast_emit::<extern fn(JitWord) -> JitWord>() };
 //! js.clear_state();
 //!
 //! assert_eq!(incr(5), 6);
@@ -50,7 +50,7 @@
 //!     js.epilog();
 //!     let end = js.note(Some(file!()), line!());
 //!
-//!     let my_function = unsafe{ js.emit::<extern fn(JitWord)>() };
+//!     let my_function = unsafe{ js.cast_emit::<extern fn(JitWord)>() };
 //!     /* call the generated code, passing its size as argument */
 //!     my_function((js.address(&end) as u64 - js.address(&start) as u64).try_into().unwrap());
 //!     js.clear_state();
@@ -96,7 +96,7 @@
 //!                 js.retr(Reg::R(0));
 //!                 js.epilog();
 //!
-//!     let fib = unsafe{ js.emit::<extern fn(JitWord) -> JitWord>() };
+//!     let fib = unsafe{ js.cast_emit::<extern fn(JitWord) -> JitWord>() };
 //!     js.clear_state();
 //!
 //!     println!("fib({})={}", 32, fib(32));
@@ -148,7 +148,7 @@
 //!                 js.patch(&f_out);
 //!                 js.retr(Reg::R(0));
 //!
-//!     let factorial = unsafe{ js.emit::<extern fn(JitWord) -> JitWord>() };
+//!     let factorial = unsafe{ js.cast_emit::<extern fn(JitWord) -> JitWord>() };
 //!     js.clear_state();
 //!
 //!     println!("factorial({}) = {}", 5, factorial(5));


### PR DESCRIPTION
Using names more consistent with the underlying library makes the job of #43 easier by reducing the number of exceptional cases required. It also makes the API more predictable for users who are familiar already with the C API.

I am interested in other suggestions for the name of `cast_emit`.