### PR TITLE
Update bindgen version requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ arch:
 
 rust:
   - stable
-  - 1.39.0
+  - 1.40.0
   - beta
   - nightly
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ lazy_static = "1.4.0"
 tt-call = "1.0"
 
 [build-dependencies]
-bindgen = { version = "0.54.1", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.55.0", default-features = false, features = ["runtime"] }
 cc = "1.0"
 
 [dev-dependencies]

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Set a Minimum Supported Rust Version (MSRV) of 1.40.0 (#49)
+
 ## [0.2.2] - 2020-08-22
 ### Added
 - Introduced `Changelog.md` (#48)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This crate links explicitly against its own packaged copy of lightning-2.1.3.
 
 ## MSRV
 
-The minimum supported Rust version is **1.39**.
+The minimum supported Rust version is **1.40**.
 
 ## Examples
 


### PR DESCRIPTION
bindgen 0.54.1 was the first version to include the required feature for `func_macro`s, but it has been yanked:

https://github.com/rust-lang/rust-bindgen/pull/1798#issuecomment-678806133

Since that time, bindgen versions 0.55.0 and 0.55.1 have been released, so we will depend on 0.55.0 and up. Since bindgen raised its MSRV to 1.40.0, we also must our MSRV to 1.40.0.