### PR TITLE
Support entry points besides `jit_new_node_*`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -76,13 +76,12 @@ fn chop_suffixes(orig: &str) -> Vec<&str> {
         return vec![orig];
     }
 
-    assert_eq!(num_underscores, 1);
-
     const SUFFIXES: &[&str] = &[
         "_f", "_d",
         "_u",
         "_c", "_i", "_l", "_s",
         "_uc", "_ui", "_ul", "_us",
+        "_p",
     ];
 
     for &suff in SUFFIXES {
@@ -340,7 +339,6 @@ fn main() -> std::io::Result<()> {
             .map(|(key, value)| {
                 (key.as_str(), std::str::from_utf8(value).unwrap())
             })
-            .filter(|(_, value)| value.contains("jit_new_node"))
             .collect();
 
     let output = make_printable(parse_macros(&relevant));

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -196,13 +196,16 @@ macro_rules! make_func {
     };
 }
 
-/// Defines an associated function for `JitState` for each `jit_entry`.
-macro_rules! jit_entry {
-    (   $entry:ident( $enum_in:ident $(, $inarg:ident )* )
-          => $root:ident
-          => [ new_node $( , $suffix:ident )* ]
-          => $invokes:ident( $jit:ident $( , $outarg:ident )* )
-    ) => {
+/// Defines an inherent method for `JitState` for each `jit_entry` that
+/// corresponds to a `jit_new_node_*` call.
+macro_rules! jit_entry_for_node {
+    {
+        $caller:tt
+        decl = [{ $entry:ident( $enum_in:ident $(, $inarg:ident )* ) }]
+        root = [{ $root:ident }]
+        parts = [{ new_node $( $suffix:ident )* }]
+        invokes = [{ $invokes:ident( $jit:ident $( , $outarg:ident )* ) }]
+    } => {
         tt_call! {
             macro = [{ jit_signature }]
             suffix = [{ $entry }]
@@ -220,11 +223,13 @@ macro_rules! jit_entry {
             }
         }
     };
-    (   $entry:ident( $( $inarg:ident ),* )
-          => $root:ident
-          => [ $stem:ident $( , $suffix:ident )* ]
-          => $invokes:ident( $enum:ident, NULL $(, $outarg:ident )* )
-    ) => {
+    {
+        $caller:tt
+        decl = [{ $entry:ident( $( $inarg:ident ),* ) }]
+        root = [{ $root:ident }]
+        parts = [{ $stem:ident $( $suffix:ident )* }]
+        invokes = [{ $invokes:ident( $enum:ident, NULL $(, $outarg:ident )* ) }]
+    } => {
         tt_call! {
             macro = [{ jit_signature }]
             suffix = [{ $invokes }]
@@ -238,11 +243,13 @@ macro_rules! jit_entry {
             }
         }
     };
-    (   $entry:ident( $( $inarg:ident ),* )
-          => $root:ident
-          => [ $stem:ident $( , $suffix:ident )* ]
-          => $invokes:ident( $enum:ident $( , $outarg:ident )* )
-    ) => {
+    {
+        $caller:tt
+        decl = [{ $entry:ident( $( $inarg:ident ),* ) }]
+        root = [{ $root:ident }]
+        parts = [{ $stem:ident $( $suffix:ident )* }]
+        invokes = [{ $invokes:ident( $enum:ident $( , $outarg:ident )* ) }]
+    } => {
         tt_call! {
             macro = [{ jit_signature }]
             suffix = [{ $invokes }]
@@ -253,6 +260,22 @@ macro_rules! jit_entry {
                 parmhead = [{ &mut self, }]
                 parmnames = [{ $( $inarg ),* }]
             }
+        }
+    };
+}
+
+macro_rules! jit_entry {
+    {   $entry:ident $inargs:tt
+            => $root:ident
+            => [ $( $parts:ident ),* ]
+            => $invokes:ident $outargs:tt
+    } => {
+        tt_call! {
+            macro = [{ jit_entry_for_node }]
+            decl = [{ $entry $inargs }]
+            root = [{ $root }]
+            parts = [{ $( $parts )* }]
+            invokes = [{ $invokes $outargs }]
         }
     };
 }
@@ -283,19 +306,25 @@ fn trivial_invocation() {
 
     impl MyDefault for jit_pointer_t { fn default() -> Self { crate::types::NULL } }
 
-    macro_rules! jit_entry {
-        (   $entry:ident( $enum_in:ident $(, $inarg:ident )* )
-              => $root:ident
-              => [ new_node $( , $suffix:ident )* ]
-              => $invokes:ident( $jit:ident $( , $outarg:ident )* )
-        ) => {
+    /// Calls the function represented by each `jit_entry` that corresponds to
+    /// a `jit_new_node_*` call.
+    macro_rules! jit_entry_for_node {
+        {
+            $caller:tt
+            decl = [{ $entry:ident( $enum_in:ident $(, $inarg:ident )* ) }]
+            root = [{ $root:ident }]
+            parts = [{ new_node $( $suffix:ident )* }]
+            invokes = [{ $invokes:ident( $enum:ident $( , $outarg:ident )* ) }]
+        } => {
             /* skip */
         };
-        (   $entry:ident( $( $inarg:ident ),* )
-              => $root:ident
-              => [ $stem:ident $( , $suffix:ident )* ]
-              => $invokes:ident( $enum:ident $( , $outarg:ident )* )
-        ) => {
+        {
+            $caller:tt
+            decl = [{ $entry:ident( $( $inarg:ident ),* ) }]
+            root = [{ $root:ident }]
+            parts = [{ $stem:ident $( $suffix:ident )* }]
+            invokes = [{ $invokes:ident( $enum:ident $( , $outarg:ident )* ) }]
+        } => {
             {
                 $( let $inarg = MyDefault::default(); )*
                 let _ = $crate::Jit::new().new_state().$entry( $( $inarg ),* );

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -66,6 +66,30 @@ macro_rules! jit_signature {
     { $c:tt suffix = [{ jit_new_node_www }] } => { tt_return!{ $c parmtypes = [{ jit_word_t, jit_word_t, jit_word_t               }] } };
 }
 
+macro_rules! is_new_node_func {
+    { $caller:tt input = [{ jit_new_node     }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_d   }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_dp  }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_f   }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_fp  }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_p   }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_pw  }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_pwd }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_pwf }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_pww }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_qww }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_w   }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_wd  }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_wf  }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_wp  }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_ww  }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_wwd }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_wwf }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+    { $caller:tt input = [{ jit_new_node_www }] } => { tt_return!{ $caller is_new_node_func = [{ true  }] } };
+
+    { $caller:tt input = [{ $( $any:tt )*    }] } => { tt_return!{ $caller is_new_node_func = [{ false }] } };
+}
+
 /// Calls `zip_params` after dropping zero or more tokens from each list.
 /// <sup>**[tt-call]**</sup>
 ///
@@ -264,18 +288,67 @@ macro_rules! jit_entry_for_node {
     };
 }
 
+macro_rules! jit_entry_non_node {
+    { $( $tokens:tt )* } => {
+        // Ignore these for now.
+    };
+}
+
 macro_rules! jit_entry {
     {   $entry:ident $inargs:tt
             => $root:ident
             => [ $( $parts:ident ),* ]
             => $invokes:ident $outargs:tt
     } => {
+        tt_if! {
+            condition = [{ is_new_node_func }]
+            input = [{ $invokes }]
+            true = [{
+                tt_call! {
+                    macro = [{ jit_entry_for_node }]
+                    decl = [{ $entry $inargs }]
+                    root = [{ $root }]
+                    parts = [{ $( $parts )* }]
+                    invokes = [{ $invokes $outargs }]
+                }
+            }]
+            false = [{
+                tt_if! {
+                    condition = [{ is_new_node_func }]
+                    input = [{ $entry }]
+                    true = [{
+                        tt_call! {
+                            macro = [{ jit_entry_for_node }]
+                            decl = [{ $entry $inargs }]
+                            root = [{ $root }]
+                            parts = [{ $( $parts )* }]
+                            invokes = [{ $invokes $outargs }]
+                        }
+                    }]
+                    false = [{
+                        tt_call! {
+                            macro = [{ jit_entry_non_node }]
+                            decl = [{ $entry $inargs }]
+                            root = [{ $root }]
+                            parts = [{ $( $parts )* }]
+                            invokes = [{ $invokes $outargs }]
+                        }
+                    }]
+                }
+            }]
+        }
+    };
+    {   $entry:ident $inargs:tt
+            => $root:ident
+            => [ $( $parts:ident ),* ]
+            => $( $other:tt )*
+    } => {
         tt_call! {
-            macro = [{ jit_entry_for_node }]
+            macro = [{ jit_entry_non_node }]
             decl = [{ $entry $inargs }]
             root = [{ $root }]
             parts = [{ $( $parts )* }]
-            invokes = [{ $invokes $outargs }]
+            invokes = [{ $( $other )* }]
         }
     };
 }


### PR DESCRIPTION
Previously, only entry points whose names started with `jit_new_node` would have a `jit_entry!` generated for them. The current pull request relaxes that restriction, laying the groundwork for generating tests in a separate PR.

Additionally, the implementation of `jit_entry!` was changed to use the [`tt-call`](https://crates.io/crates/tt-call) macro calling convention in order to take advantage of `tt-call`'s predicates. Unfortunately, this makes the macro definitions significantly more verbose than they were previously.