### PR TITLE
Collect minor code improvements

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -124,13 +124,8 @@ mod tests {
     fn test_to_ffi() {
         let jit = Jit::new();
 
-        let _ = Reg::R(jit.r_num()-1).to_ffi();
-        let _ = Reg::R(0).to_ffi();
-
-        let _ = Reg::V(jit.v_num()-1).to_ffi();
-        let _ = Reg::V(0).to_ffi();
-
-        let _ = Reg::F(jit.f_num()-1).to_ffi();
-        let _ = Reg::F(0).to_ffi();
+        for n in 0..jit.r_num() { let _ = Reg::R(n).to_ffi(); }
+        for n in 0..jit.v_num() { let _ = Reg::V(n).to_ffi(); }
+        for n in 0..jit.f_num() { let _ = Reg::F(n).to_ffi(); }
     }
 }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::mutex_atomic)] // Avoid clippy warning about JITS_MADE
 #![allow(clippy::new_without_default)] // Avoid clippy warning about Jit::new
+#![deny(unused_must_use)]
 
 use std::sync::Mutex;
 
@@ -16,6 +17,7 @@ lazy_static! {
 }
 
 impl<'a> Jit<'a> {
+    #[must_use]
     pub fn new() -> Jit<'a> {
         let mut m = JITS_MADE.lock().unwrap();
 
@@ -32,6 +34,7 @@ impl<'a> Jit<'a> {
 
     // This takes &mut self instead of &self because the unsafe operations wrapped herein are
     // inherently mutating.
+    #[must_use]
     pub fn new_state(&mut self) -> JitState {
         JitState {
             state: unsafe {
@@ -41,18 +44,21 @@ impl<'a> Jit<'a> {
         }
     }
 
+    #[must_use]
     pub fn r_num(&self) -> bindings::jit_gpr_t {
         unsafe {
             bindings::lgsys_JIT_R_NUM()
         }
     }
 
+    #[must_use]
     pub fn v_num(&self) -> bindings::jit_gpr_t {
         unsafe {
             bindings::lgsys_JIT_V_NUM()
         }
     }
 
+    #[must_use]
     pub fn f_num(&self) -> bindings::jit_gpr_t {
         unsafe {
             bindings::lgsys_JIT_F_NUM()
@@ -84,12 +90,12 @@ mod tests {
     fn test_jit() {
         {
             let _jit = Jit::new();
-            Jit::new();
+            let _ = Jit::new();
         }
 
         {
             let _jit = Jit::new();
-            Jit::new();
+            let _ = Jit::new();
         }
 
     }
@@ -107,15 +113,15 @@ mod tests {
         let jit = Jit::new();
 
         assert!(std::panic::catch_unwind(|| Reg::R(jit.r_num()).to_ffi()).is_err());
-        Reg::R(jit.r_num()-1).to_ffi();
-        Reg::R(0).to_ffi();
+        let _ = Reg::R(jit.r_num()-1).to_ffi();
+        let _ = Reg::R(0).to_ffi();
 
         assert!(std::panic::catch_unwind(|| Reg::V(jit.v_num()).to_ffi()).is_err());
-        Reg::V(jit.v_num()-1).to_ffi();
-        Reg::V(0).to_ffi();
+        let _ = Reg::V(jit.v_num()-1).to_ffi();
+        let _ = Reg::V(0).to_ffi();
 
         assert!(std::panic::catch_unwind(|| Reg::F(jit.f_num()).to_ffi()).is_err());
-        Reg::F(jit.f_num()-1).to_ffi();
-        Reg::F(0).to_ffi();
+        let _ = Reg::F(jit.f_num()-1).to_ffi();
+        let _ = Reg::F(0).to_ffi();
     }
 }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -109,18 +109,27 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
+    fn test_r_invalid() { let _ = Reg::R(Jit::new().r_num()).to_ffi(); }
+
+    #[test]
+    #[should_panic]
+    fn test_v_invalid() { let _ = Reg::R(Jit::new().v_num()).to_ffi(); }
+
+    #[test]
+    #[should_panic]
+    fn test_f_invalid() { let _ = Reg::R(Jit::new().f_num()).to_ffi(); }
+
+    #[test]
     fn test_to_ffi() {
         let jit = Jit::new();
 
-        assert!(std::panic::catch_unwind(|| Reg::R(jit.r_num()).to_ffi()).is_err());
         let _ = Reg::R(jit.r_num()-1).to_ffi();
         let _ = Reg::R(0).to_ffi();
 
-        assert!(std::panic::catch_unwind(|| Reg::V(jit.v_num()).to_ffi()).is_err());
         let _ = Reg::V(jit.v_num()-1).to_ffi();
         let _ = Reg::V(0).to_ffi();
 
-        assert!(std::panic::catch_unwind(|| Reg::F(jit.f_num()).to_ffi()).is_err());
         let _ = Reg::F(jit.f_num()-1).to_ffi();
         let _ = Reg::F(0).to_ffi();
     }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -45,21 +45,21 @@ impl<'a> Jit<'a> {
     }
 
     #[must_use]
-    pub fn r_num(&self) -> bindings::jit_gpr_t {
+    pub fn r_num() -> bindings::jit_gpr_t {
         unsafe {
             bindings::lgsys_JIT_R_NUM()
         }
     }
 
     #[must_use]
-    pub fn v_num(&self) -> bindings::jit_gpr_t {
+    pub fn v_num() -> bindings::jit_gpr_t {
         unsafe {
             bindings::lgsys_JIT_V_NUM()
         }
     }
 
     #[must_use]
-    pub fn f_num(&self) -> bindings::jit_gpr_t {
+    pub fn f_num() -> bindings::jit_gpr_t {
         unsafe {
             bindings::lgsys_JIT_F_NUM()
         }
@@ -102,30 +102,27 @@ mod tests {
 
     #[test]
     fn test_reg_num() {
-        let jit = Jit::new();
-        assert!(jit.r_num() >= 3);
-        assert!(jit.v_num() >= 3);
-        assert!(jit.f_num() >= 6);
+        assert!(Jit::r_num() >= 3);
+        assert!(Jit::v_num() >= 3);
+        assert!(Jit::f_num() >= 6);
     }
 
     #[test]
     #[should_panic]
-    fn test_r_invalid() { let _ = Reg::R(Jit::new().r_num()).to_ffi(); }
+    fn test_r_invalid() { let _ = Reg::R(Jit::r_num()).to_ffi(); }
 
     #[test]
     #[should_panic]
-    fn test_v_invalid() { let _ = Reg::R(Jit::new().v_num()).to_ffi(); }
+    fn test_v_invalid() { let _ = Reg::R(Jit::v_num()).to_ffi(); }
 
     #[test]
     #[should_panic]
-    fn test_f_invalid() { let _ = Reg::R(Jit::new().f_num()).to_ffi(); }
+    fn test_f_invalid() { let _ = Reg::R(Jit::f_num()).to_ffi(); }
 
     #[test]
     fn test_to_ffi() {
-        let jit = Jit::new();
-
-        for n in 0..jit.r_num() { let _ = Reg::R(n).to_ffi(); }
-        for n in 0..jit.v_num() { let _ = Reg::V(n).to_ffi(); }
-        for n in 0..jit.f_num() { let _ = Reg::F(n).to_ffi(); }
+        for n in 0..Jit::r_num() { let _ = Reg::R(n).to_ffi(); }
+        for n in 0..Jit::v_num() { let _ = Reg::V(n).to_ffi(); }
+        for n in 0..Jit::f_num() { let _ = Reg::F(n).to_ffi(); }
     }
 }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1,8 +1,6 @@
 #![allow(clippy::mutex_atomic)] // Avoid clippy warning about JITS_MADE
 #![allow(clippy::new_without_default)] // Avoid clippy warning about Jit::new
 
-use std::os::raw;
-use std::ptr;
 use std::sync::Mutex;
 
 use crate::bindings;
@@ -24,7 +22,7 @@ impl<'a> Jit<'a> {
         if *m == 0 {
             unsafe {
                 //TODO: figure out how to get ptr to argv[0]
-                bindings::init_jit(ptr::null::<raw::c_char>());
+                bindings::init_jit(std::ptr::null());
             }
         }
 

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -279,11 +279,15 @@ impl<'a> JitState<'a> {
     jit_impl!(live, w);
     jit_impl!(align, w);
 
-    pub fn name(&mut self, name: &str) -> JitNode<'a> {
+    pub fn name(&mut self, name: Option<&str>) -> JitNode<'a> {
         // I looked at the lightning code, this will be copied
-        let cs = CString::new(name).unwrap();
+        let cs = name
+            .map(CString::new)
+            .map(Result::unwrap)
+            .map(|c| c.as_ptr())
+            .unwrap_or(core::ptr::null());
         JitNode{
-            node: unsafe { bindings::_jit_name(self.state, cs.as_ptr()) },
+            node: unsafe { bindings::_jit_name(self.state, cs) },
             phantom: std::marker::PhantomData,
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -24,6 +24,7 @@ pub const NULL: JitPointer = null_mut::<c_void>();
 
 pub(crate) trait ToFFI {
     type Type;
+    #[must_use]
     fn to_ffi(&self) -> Self::Type;
 }
 


### PR DESCRIPTION
The current PR collects some disparate improvements in code usability and consistency.

Notably, some functions are marked with `#[must_use]` to ensure they are not called in the mistaken belief that they mutate their referent.

Also, the register-lookup functions become associated functions, since they are never (on any platform) dependent on the actual runtime state.