### PR TITLE
Test entry points using mechanization

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -367,6 +367,8 @@ include!(concat!(env!("OUT_DIR"), "/entries.rs"));
 #[allow(unreachable_code)]
 #[allow(unused_variables)]
 fn trivial_invocation() {
+    let mut new_node_count = 0;
+
     trait MyDefault { fn default() -> Self; }
 
     impl MyDefault for jit_word_t    { fn default() -> Self { Default::default() } }
@@ -389,6 +391,7 @@ fn trivial_invocation() {
             parts = [{ new_node $( $suffix:ident )* }]
             invokes = [{ $invokes:ident( $enum:ident $( , $outarg:ident )* ) }]
         } => {
+            new_node_count += 1;
             /* skip */
         };
         {
@@ -412,5 +415,7 @@ fn trivial_invocation() {
     }
 
     include!{ concat!(env!("OUT_DIR"), "/entries.rs") }
+
+    assert_eq!(new_node_count, 19, "an unexpected number of jit_new_node* entry points were seen");
 }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -368,6 +368,7 @@ include!(concat!(env!("OUT_DIR"), "/entries.rs"));
 #[allow(unused_variables)]
 fn trivial_invocation() {
     let mut new_node_count = 0;
+    let mut entry_count = 0;
 
     trait MyDefault { fn default() -> Self; }
 
@@ -402,6 +403,7 @@ fn trivial_invocation() {
             invokes = [{ $invokes:ident( $enum:ident $( , $outarg:ident )* ) }]
         } => {
             {
+                entry_count += 1;
                 $( let $inarg = MyDefault::default(); )*
                 let _ = $crate::Jit::new().new_state().$entry( $( $inarg ),* );
             }
@@ -417,5 +419,6 @@ fn trivial_invocation() {
     include!{ concat!(env!("OUT_DIR"), "/entries.rs") }
 
     assert_eq!(new_node_count, 19, "an unexpected number of jit_new_node* entry points were seen");
+    assert!(entry_count > 320, "an unexpected number of jit_new_node* callers were seen");
 }
 


### PR DESCRIPTION
Although generating full unit tests automatically for each entry point is infeasible, we can at least test for entry-point existence in every case, and for the correct number of arguments in most cases.

Additionally, we can test for approximately the right number of total entry points, in order to catch some types of errors during generation of `entries.rs`.