### PR TITLE
Generate entry points via mechanization and pattern matching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/petelliott/lightning-sys"
 documentation = "https://docs.rs/lightning-sys"
 
 [dependencies]
-paste = "0.1.18"
 lazy_static = "1.4.0"
 tt-call = "1.0"
 

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -3,8 +3,8 @@ use crate::Reg;
 use crate::JitNode;
 use crate::{JitWord, JitPointer};
 use crate::ToFFI;
-use std::ffi::{CString, c_void};
-use std::ptr::null_mut;
+use std::ffi::CString;
+use tt_call::*;
 
 #[derive(Debug)]
 pub struct JitState<'a> {
@@ -18,80 +18,6 @@ impl<'a> Drop for JitState<'a> {
             bindings::_jit_destroy_state(self.state);
         }
     }
-}
-
-
-macro_rules! jit_impl {
-    ( $op:ident, _ ) => { jit_impl_inner!($op, _); };
-
-    ( $op:ident, w ) => { jit_impl_inner!($op, w, a: Reg => JitWord); };
-    //( $op:ident, f ) => { jit_impl_inner!($op, f, a: Reg => JitWord); };
-    //( $op:ident, d ) => { jit_impl_inner!($op, d, a: Reg => JitWord); };
-    //( $op:ident, p ) => { jit_impl_inner!($op, p, a: Reg => JitWord); };
-
-    ( $op:ident, i_w ) => { jit_impl_inner!($op, w, a: JitWord => _); };
-    ( $op:ident, i_f ) => { jit_impl_inner!($op, f, a: f32 => _); };
-    ( $op:ident, i_d ) => { jit_impl_inner!($op, d, a: f64 => _); };
-    ( $op:ident, i_p ) => { jit_impl_inner!($op, p, a: JitPointer => _); };
-
-    ( $op:ident, ww ) => { jit_impl_inner!($op, ww, a: Reg => JitWord, b: Reg => JitWord); };
-    //( $op:ident, wp ) => { jit_impl_inner!($op, wp, a: Reg => JitWord, b: Reg => JitWord); };
-    //( $op:ident, fp ) => { jit_impl_inner!($op, fp, a: Reg => JitWord, b: Reg => JitWord); };
-    //( $op:ident, dp ) => { jit_impl_inner!($op, dp, a: Reg => JitWord, b: Reg => JitWord); };
-    //( $op:ident, pw ) => { jit_impl_inner!($op, pw, a: Reg => JitWord, b: Reg => JitWord); };
-    //( $op:ident, wf ) => { jit_impl_inner!($op, wf, a: Reg => JitWord, b: Reg => JitWord); };
-    //( $op:ident, wd ) => { jit_impl_inner!($op, wd, a: Reg => JitWord, b: Reg => JitWord); };
-
-    ( $op:ident, i_ww ) => { jit_impl_inner!($op, ww, a: Reg => JitWord, b: JitWord => _); };
-    ( $op:ident, i_wp ) => { jit_impl_inner!($op, wp, a: Reg => JitWord, b: JitPointer => _); };
-    ( $op:ident, i_fp ) => { jit_impl_inner!($op, fp, a: Reg => JitWord, b: JitPointer => _); };
-    ( $op:ident, i_dp ) => { jit_impl_inner!($op, dp, a: Reg => JitWord, b: JitPointer => _); };
-    ( $op:ident, i_pw ) => { jit_impl_inner!($op, pw, a: JitPointer => _, b: Reg => JitWord); };
-    ( $op:ident, i_wf ) => { jit_impl_inner!($op, wf, a: Reg => JitWord, b: f32 => _); };
-    ( $op:ident, i_wd ) => { jit_impl_inner!($op, wd, a: Reg => JitWord, b: f64 => _); };
-
-    ( $op:ident, www ) => { jit_impl_inner!($op, www, a: Reg => JitWord, b: Reg => JitWord, c: Reg => JitWord); };
-    //( $op:ident, wwf ) => { jit_impl_inner!($op, wwf, a: Reg => JitWord, b: Reg => JitWord, c: Reg => JitWord); };
-    //( $op:ident, wwd ) => { jit_impl_inner!($op, wwd, a: Reg => JitWord, b: Reg => JitWord, c: Reg => JitWord); };
-    //( $op:ident, pww ) => { jit_impl_inner!($op, pww, a: Reg => JitWord, b: Reg => JitWord, c: Reg => JitWord); };
-    //( $op:ident, pwf ) => { jit_impl_inner!($op, pwf, a: Reg => JitWord, b: Reg => JitWord, c: Reg => JitWord); };
-    //( $op:ident, pwd ) => { jit_impl_inner!($op, pwd, a: Reg => JitWord, b: Reg => JitWord, c: Reg => JitWord); };
-
-    ( $op:ident, i_www ) => { jit_impl_inner!($op, www, a: Reg => JitWord, b: Reg => JitWord, c: JitWord => _); };
-    ( $op:ident, i_wwf ) => { jit_impl_inner!($op, wwf, a: Reg => JitWord, b: Reg => JitWord, c: f32 => _); };
-    ( $op:ident, i_wwd ) => { jit_impl_inner!($op, wwd, a: Reg => JitWord, b: Reg => JitWord, c: f64 => _); };
-    ( $op:ident, i_pww ) => { jit_impl_inner!($op, pww, a: Reg => JitWord, b: Reg => JitWord, c: JitWord => _); };
-    ( $op:ident, i_pwf ) => { jit_impl_inner!($op, pwf, a: Reg => JitWord, b: Reg => JitWord, c: f32 => _); };
-    ( $op:ident, i_pwd ) => { jit_impl_inner!($op, pwd, a: Reg => JitWord, b: Reg => JitWord, c: f64 => _); };
-
-    ( $op:ident, qww ) => { jit_impl_inner!($op, qww, a: Reg => i32, b: Reg => i32, c: Reg => JitWord, d: Reg => JitWord); };
-    ( $op:ident, i_qww ) => { jit_impl_inner!($op, qww, a: Reg => i32, b: Reg => i32, c: Reg => JitWord, d: JitWord => _); };
-}
-
-macro_rules! jit_store {
-    ( $op:ident, ww ) => { jit_impl_inner!($op, ww, a: Reg => JitWord, b: Reg => JitWord); };
-
-    ( $op:ident, i_pw ) => { jit_impl_inner!($op, pw, a: JitPointer => _, b: Reg => JitWord); };
-
-    ( $op:ident, www ) => { jit_impl_inner!($op, www, a: Reg => JitWord, b: Reg => JitWord, c: Reg => JitWord); };
-
-    ( $op:ident, i_www ) => { jit_impl_inner!($op, www, a: JitWord => _, b: Reg => JitWord, c: Reg => JitWord); };
-
-}
-
-macro_rules! jit_impl_inner {
-    ( $op:ident, $ifmt:ident $(, $arg:ident: $type:ty => $target:ty)* ) => {
-        paste::item! {
-            pub fn $op(&mut self $(, $arg: $type)*) -> JitNode<'a> {
-                unsafe {
-                    self.[< jit_ $op >]($( $arg.to_ffi().into() ),*)
-                }
-            }
-        }
-    };
-    ( $op:ident, $ifmt:ident $(, $arg:ident: $type:ty)* ) => {
-        jit_impl_inner!(kkk);
-    };
 }
 
 macro_rules! jit_reexport {
@@ -120,26 +46,6 @@ macro_rules! jit_reexport {
         }
     };
     ( $fn:ident $(, $arg:ident : $typ:ty )*) => { jit_reexport!($fn $(, $arg : $typ)*; -> ()); }
-}
-
-macro_rules! jit_imm {
-    (i) => { JitWord };
-    (r) => { Reg };
-    (f) => { f32 };
-    (d) => { f64 };
-}
-
-macro_rules! jit_branch {
-    ( $fn:ident, $t:ident ) => {
-        paste::item! {
-            pub fn $fn(&mut self, a: Reg, b: jit_imm!($t)) -> JitNode<'a> {
-                JitNode{
-                    node: unsafe{ bindings::_jit_new_node_pww(self.state, bindings::jit_code_t::[< jit_code_ $fn >], null_mut::<c_void>(), a.to_ffi() as JitWord, b.to_ffi() as JitWord) },
-                    phantom: std::marker::PhantomData,
-                }
-            }
-        }
-    };
 }
 
 macro_rules! jit_alias {
@@ -276,8 +182,6 @@ impl<'a> JitState<'a> {
 
 /// implementations of general instructions
 impl<'a> JitState<'a> {
-    jit_impl!(live, w);
-    jit_impl!(align, w);
 
     pub fn name(&mut self, name: Option<&str>) -> JitNode<'a> {
         // I looked at the lightning code, this will be copied
@@ -331,227 +235,11 @@ impl<'a> JitState<'a> {
     jit_reexport!(putargr, reg: Reg, arg: &JitNode<'a>);
     jit_reexport!(putargi, imm: JitWord, arg: &JitNode<'a>);
 
-    jit_impl!(va_start, w);
-    jit_impl!(va_arg, ww);
-    jit_impl!(va_arg_d, ww);
     jit_reexport!(va_push, arg: Reg);
-    jit_impl!(va_end, w);
-
-    jit_impl!(addr, www);
-    jit_impl!(addi, i_www);
-    jit_impl!(addcr, www);
-    jit_impl!(addci, i_www);
-    jit_impl!(addxr, www);
-    jit_impl!(addxi, i_www);
-    jit_impl!(subr, www);
-    jit_impl!(subi, i_www);
-    jit_impl!(subcr, www);
-    jit_impl!(subci, i_www);
-    jit_impl!(subxr, www);
-    jit_impl!(subxi, i_www);
 
     pub fn rsbr(&mut self, a: Reg, b: Reg, c: Reg) -> JitNode<'a> {
         self.subr(a, c, b)
     }
-
-    jit_impl!(rsbi, i_www);
-
-    jit_impl!(mulr, www);
-    jit_impl!(muli, i_www);
-    jit_impl!(qmulr, qww);
-    jit_impl!(qmuli, i_qww);
-    jit_impl!(qmulr_u, qww);
-    jit_impl!(qmuli_u, i_qww);
-    jit_impl!(divr, www);
-    jit_impl!(divi, i_www);
-    jit_impl!(divr_u, www);
-    jit_impl!(divi_u, i_www);
-    jit_impl!(qdivr, qww);
-    jit_impl!(qdivi, i_qww);
-    jit_impl!(qdivr_u, qww);
-    jit_impl!(qdivi_u, i_qww);
-    jit_impl!(remr, www);
-    jit_impl!(remi, i_www);
-    jit_impl!(remr_u, www);
-    jit_impl!(remi_u, i_www);
-
-    jit_impl!(andr, www);
-    jit_impl!(andi, i_www);
-    jit_impl!(orr, www);
-    jit_impl!(ori, i_www);
-    jit_impl!(xorr, www);
-    jit_impl!(xori, i_www);
-
-    jit_impl!(lshr, www);
-    jit_impl!(lshi, i_www);
-    jit_impl!(rshr, www);
-    jit_impl!(rshi, i_www);
-    jit_impl!(rshi_u, i_www);
-    jit_impl!(rshr_u, www);
-
-    jit_impl!(negr, ww);
-    jit_impl!(comr, ww);
-
-    jit_impl!(ltr, www);
-    jit_impl!(lti, i_www);
-    jit_impl!(ltr_u, www);
-    jit_impl!(lti_u, i_www);
-    jit_impl!(ler, www);
-    jit_impl!(lei, i_www);
-    jit_impl!(ler_u, www);
-    jit_impl!(lei_u, i_www);
-    jit_impl!(eqr, www);
-    jit_impl!(eqi, i_www);
-    jit_impl!(ger, www);
-    jit_impl!(ger_u, www);
-    jit_impl!(gei, i_www);
-    jit_impl!(gei_u, i_www);
-    jit_impl!(gtr, www);
-    jit_impl!(gti, i_www);
-    jit_impl!(gtr_u, www);
-    jit_impl!(gti_u, i_www);
-    jit_impl!(ner, www);
-    jit_impl!(nei, i_www);
-
-    jit_impl!(movr, ww);
-    jit_impl!(movi, i_ww);
-
-    jit_impl!(extr_c, ww);
-    jit_impl!(extr_uc, ww);
-    jit_impl!(extr_s, ww);
-    jit_impl!(extr_us, ww);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(extr_i, ww);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(extr_ui, ww);
-
-    jit_impl!(htonr_us, ww);
-    jit_alias!(htonr_us => ntohr_us, targ: Reg, src: Reg; -> JitNode<'a>);
-    jit_impl!(htonr_ui, ww);
-    jit_alias!(htonr_ui => ntohr_ui, targ: Reg, src: Reg; -> JitNode<'a>);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(htonr_ul, ww);
-    #[cfg(target_pointer_width = "64")]
-    jit_alias!(htonr_ul => ntohr_ul, targ: Reg, src: Reg; -> JitNode<'a>);
-    #[cfg(target_pointer_width = "32")]
-    jit_alias!(htonr_ui => htonr, targ: Reg, src: Reg; -> JitNode<'a>);
-    #[cfg(target_pointer_width = "64")]
-    jit_alias!(htonr_ul => htonr, targ: Reg, src: Reg; -> JitNode<'a>);
-    jit_alias!(htonr => ntohr, targ: Reg, src: Reg; -> JitNode<'a>);
-
-    jit_impl!(ldr_c, ww);
-    jit_impl!(ldi_c, i_wp);
-    jit_impl!(ldr_uc, ww);
-    jit_impl!(ldi_uc, i_wp);
-    jit_impl!(ldr_s, ww);
-    jit_impl!(ldi_s, i_wp);
-    jit_impl!(ldr_us, ww);
-    jit_impl!(ldi_us, i_wp);
-    jit_impl!(ldr_i, ww);
-    jit_impl!(ldi_i, i_wp);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(ldr_ui, ww);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(ldi_ui, i_wp);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(ldr_l, ww);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(ldi_l, i_wp);
-
-    jit_impl!(ldxr_c, www);
-    jit_impl!(ldxi_c, i_www);
-    jit_impl!(ldxr_uc, www);
-    jit_impl!(ldxi_uc, i_www);
-    jit_impl!(ldxr_s, www);
-    jit_impl!(ldxi_s, i_www);
-    jit_impl!(ldxr_us, www);
-    jit_impl!(ldxi_us, i_www);
-    jit_impl!(ldxr_i, www);
-    jit_impl!(ldxi_i, i_www);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(ldxr_ui, www);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(ldxi_ui, i_www);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(ldxr_l, www);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(ldxi_l, i_www);
-
-    jit_store!(str_c, ww);
-    jit_store!(sti_c, i_pw);
-    jit_store!(str_s, ww);
-    jit_store!(sti_s, i_pw);
-    jit_store!(str_i, ww);
-    jit_store!(sti_i, i_pw);
-    #[cfg(target_pointer_width = "64")]
-    jit_store!(str_l, ww);
-    #[cfg(target_pointer_width = "64")]
-    jit_store!(sti_l, i_pw);
-
-    jit_store!(stxr_c, www);
-    jit_store!(stxi_c, i_www);
-    jit_store!(stxr_s, www);
-    jit_store!(stxi_s, i_www);
-    jit_store!(stxr_i, www);
-    jit_store!(stxi_i, i_www);
-    #[cfg(target_pointer_width = "64")]
-    jit_store!(stxr_l, www);
-    #[cfg(target_pointer_width = "64")]
-    jit_store!(stxi_l, i_www);
-
-    jit_branch!(bltr, r);
-    jit_branch!(blti, i);
-    jit_branch!(bltr_u, r);
-    jit_branch!(blti_u, i);
-    jit_branch!(bler, r);
-    jit_branch!(blei, i);
-    jit_branch!(bler_u, r);
-    jit_branch!(blei_u, i);
-    jit_branch!(beqr, r);
-    jit_branch!(beqi, i);
-    jit_branch!(bger, r);
-    jit_branch!(bgei, i);
-    jit_branch!(bger_u, r);
-    jit_branch!(bgei_u, i);
-    jit_branch!(bgtr, r);
-    jit_branch!(bgti, i);
-    jit_branch!(bgtr_u, r);
-    jit_branch!(bgti_u, i);
-    jit_branch!(bner, r);
-    jit_branch!(bnei, i);
-    jit_branch!(bmsr, r);
-    jit_branch!(bmsi, i);
-    jit_branch!(bmcr, r);
-    jit_branch!(bmci, i);
-    jit_branch!(boaddr, r);
-    jit_branch!(boaddi, i);
-    jit_branch!(boaddr_u, r);
-    jit_branch!(boaddi_u, i);
-    jit_branch!(bxaddr, r);
-    jit_branch!(bxaddi, i);
-    jit_branch!(bxaddr_u, r);
-    jit_branch!(bxaddi_u, i);
-    jit_branch!(bosubr, r);
-    jit_branch!(bosubi, i);
-    jit_branch!(bosubr_u, r);
-    jit_branch!(bosubi_u, i);
-    jit_branch!(bxsubr, r);
-    jit_branch!(bxsubi, i);
-    jit_branch!(bxsubr_u, r);
-    jit_branch!(bxsubi_u, i);
-
-    jit_impl!(jmpr, w);
-
-    pub fn jmpi(&mut self) -> JitNode<'a> {
-        // I looked at the lightning code, this will be copied
-        JitNode{
-            node: unsafe { bindings::_jit_new_node_p(self.state, bindings::jit_code_t::jit_code_jmpi, std::ptr::null_mut::<c_void >()) },
-            phantom: std::marker::PhantomData,
-        }
-    }
-
-    jit_impl!(callr, w);
-    jit_impl!(calli, i_p);
 
     jit_reexport!(prepare);
     jit_reexport!(pushargr, arg: Reg);
@@ -602,100 +290,9 @@ impl<'a> JitState<'a> {
     jit_reexport!(putargr_f, reg: Reg, arg: &JitNode<'a>);
     jit_reexport!(putargi_f, imm: f32, arg: &JitNode<'a>);
 
-    jit_impl!(addr_f, www);
-    jit_impl!(addi_f, i_wwf);
-    jit_impl!(subr_f, www);
-    jit_impl!(subi_f, i_wwf);
-
     pub fn rsbr_f(&mut self, a: Reg, b: Reg, c: Reg) -> JitNode<'a> {
         self.subr_f(a, c, b)
     }
-
-    jit_impl!(rsbi_f, i_wwf);
-    jit_impl!(mulr_f, www);
-    jit_impl!(muli_f, i_wwf);
-    jit_impl!(divr_f, www);
-    jit_impl!(divi_f, i_wwf);
-    jit_impl!(negr_f, ww);
-    jit_impl!(absr_f, ww);
-    jit_impl!(sqrtr_f, ww);
-
-    jit_impl!(ltr_f, www);
-    jit_impl!(lti_f, i_wwf);
-    jit_impl!(ler_f, www);
-    jit_impl!(lei_f, i_wwf);
-    jit_impl!(eqr_f, www);
-    jit_impl!(eqi_f, i_wwf);
-    jit_impl!(ger_f, www);
-    jit_impl!(gei_f, i_wwf);
-    jit_impl!(gtr_f, www);
-    jit_impl!(gti_f, i_wwf);
-    jit_impl!(ner_f, www);
-    jit_impl!(nei_f, i_wwf);
-    jit_impl!(unltr_f, www);
-    jit_impl!(unlti_f, i_wwf);
-    jit_impl!(unler_f, www);
-    jit_impl!(unlei_f, i_wwf);
-    jit_impl!(uneqr_f, www);
-    jit_impl!(uneqi_f, i_wwf);
-    jit_impl!(unger_f, www);
-    jit_impl!(ungei_f, i_wwf);
-    jit_impl!(ungtr_f, www);
-    jit_impl!(ungti_f, i_wwf);
-    jit_impl!(ltgtr_f, www);
-    jit_impl!(ltgti_f, i_wwf);
-    jit_impl!(ordr_f, www);
-    jit_impl!(ordi_f, i_wwf);
-    jit_impl!(unordr_f, www);
-    jit_impl!(unordi_f, i_wwf);
-
-    jit_impl!(truncr_f_i, ww);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(truncr_f_l, ww);
-
-    jit_impl!(extr_f, ww);
-    jit_impl!(extr_d_f, ww);
-    jit_impl!(movr_f, ww);
-    jit_impl!(movi_f, i_wf);
-
-    jit_impl!(ldr_f, ww);
-    jit_impl!(ldi_f, i_wp);
-    jit_impl!(ldxr_f, www);
-    jit_impl!(ldxi_f, i_www);
-
-    jit_store!(str_f, ww);
-    jit_store!(sti_f, i_pw);
-    jit_store!(stxr_f, www);
-    jit_store!(stxi_f, i_www);
-
-    jit_branch!(bltr_f, r);
-    jit_branch!(blti_f, f);
-    jit_branch!(bler_f, r);
-    jit_branch!(blei_f, f);
-    jit_branch!(beqr_f, r);
-    jit_branch!(beqi_f, f);
-    jit_branch!(bger_f, r);
-    jit_branch!(bgei_f, f);
-    jit_branch!(bgtr_f, r);
-    jit_branch!(bgti_f, f);
-    jit_branch!(bner_f, r);
-    jit_branch!(bnei_f, f);
-    jit_branch!(bunltr_f, r);
-    jit_branch!(bunlti_f, f);
-    jit_branch!(bunler_f, r);
-    jit_branch!(bunlei_f, f);
-    jit_branch!(buneqr_f, r);
-    jit_branch!(buneqi_f, f);
-    jit_branch!(bunger_f, r);
-    jit_branch!(bungei_f, f);
-    jit_branch!(bungtr_f, r);
-    jit_branch!(bungti_f, f);
-    jit_branch!(bltgtr_f, r);
-    jit_branch!(bltgti_f, f);
-    jit_branch!(bordr_f, r);
-    jit_branch!(bordi_f, f);
-    jit_branch!(bunordr_f, r);
-    jit_branch!(bunordi_f, f);
 
     jit_reexport!(pushargr_f, reg: Reg);
     jit_reexport!(pushargi_f, imm: f32);
@@ -711,100 +308,9 @@ impl<'a> JitState<'a> {
     jit_reexport!(putargr_d, reg: Reg, arg: &JitNode<'a>);
     jit_reexport!(putargi_d, imm: f64, arg: &JitNode<'a>);
 
-    jit_impl!(addr_d, www);
-    jit_impl!(addi_d, i_wwd);
-    jit_impl!(subr_d, www);
-    jit_impl!(subi_d, i_wwd);
-
     pub fn rsbr_d(&mut self, a: Reg, b: Reg, c: Reg) -> JitNode<'a> {
         self.subr_d(a, c, b)
     }
-
-    jit_impl!(rsbi_d, i_wwd);
-    jit_impl!(mulr_d, www);
-    jit_impl!(muli_d, i_wwd);
-    jit_impl!(divr_d, www);
-    jit_impl!(divi_d, i_wwd);
-    jit_impl!(negr_d, ww);
-    jit_impl!(absr_d, ww);
-    jit_impl!(sqrtr_d, ww);
-
-    jit_impl!(ltr_d, www);
-    jit_impl!(lti_d, i_wwd);
-    jit_impl!(ler_d, www);
-    jit_impl!(lei_d, i_wwd);
-    jit_impl!(eqr_d, www);
-    jit_impl!(eqi_d, i_wwd);
-    jit_impl!(ger_d, www);
-    jit_impl!(gei_d, i_wwd);
-    jit_impl!(gtr_d, www);
-    jit_impl!(gti_d, i_wwd);
-    jit_impl!(ner_d, www);
-    jit_impl!(nei_d, i_wwd);
-    jit_impl!(unltr_d, www);
-    jit_impl!(unlti_d, i_wwd);
-    jit_impl!(unler_d, www);
-    jit_impl!(unlei_d, i_wwd);
-    jit_impl!(uneqr_d, www);
-    jit_impl!(uneqi_d, i_wwd);
-    jit_impl!(unger_d, www);
-    jit_impl!(ungei_d, i_wwd);
-    jit_impl!(ungtr_d, www);
-    jit_impl!(ungti_d, i_wwd);
-    jit_impl!(ltgtr_d, www);
-    jit_impl!(ltgti_d, i_wwd);
-    jit_impl!(ordr_d, www);
-    jit_impl!(ordi_d, i_wwd);
-    jit_impl!(unordr_d, www);
-    jit_impl!(unordi_d, i_wwd);
-
-    jit_impl!(truncr_d_i, ww);
-    #[cfg(target_pointer_width = "64")]
-    jit_impl!(truncr_d_l, ww);
-
-    jit_impl!(extr_d, ww);
-    jit_impl!(extr_f_d, ww);
-    jit_impl!(movr_d, ww);
-    jit_impl!(movi_d, i_wd);
-
-    jit_impl!(ldr_d, ww);
-    jit_impl!(ldi_d, i_wp);
-    jit_impl!(ldxr_d, www);
-    jit_impl!(ldxi_d, i_www);
-
-    jit_store!(str_d, ww);
-    jit_store!(sti_d, i_pw);
-    jit_store!(stxr_d, www);
-    jit_store!(stxi_d, i_www);
-
-    jit_branch!(bltr_d, r);
-    jit_branch!(blti_d, d);
-    jit_branch!(bler_d, r);
-    jit_branch!(blei_d, d);
-    jit_branch!(beqr_d, r);
-    jit_branch!(beqi_d, d);
-    jit_branch!(bger_d, r);
-    jit_branch!(bgei_d, d);
-    jit_branch!(bgtr_d, r);
-    jit_branch!(bgti_d, d);
-    jit_branch!(bner_d, r);
-    jit_branch!(bnei_d, d);
-    jit_branch!(bunltr_d, r);
-    jit_branch!(bunlti_d, d);
-    jit_branch!(bunler_d, r);
-    jit_branch!(bunlei_d, d);
-    jit_branch!(buneqr_d, r);
-    jit_branch!(buneqi_d, d);
-    jit_branch!(bunger_d, r);
-    jit_branch!(bungei_d, d);
-    jit_branch!(bungtr_d, r);
-    jit_branch!(bungti_d, d);
-    jit_branch!(bltgtr_d, r);
-    jit_branch!(bltgti_d, d);
-    jit_branch!(bordr_d, r);
-    jit_branch!(bordi_d, d);
-    jit_branch!(bunordr_d, r);
-    jit_branch!(bunordi_d, d);
 
     jit_reexport!(pushargr_d, reg: Reg);
     jit_reexport!(pushargi_d, imm: f64);
@@ -815,11 +321,118 @@ impl<'a> JitState<'a> {
 
 /// Defines an inherent method for `JitState` for each `jit_entry` that
 /// corresponds to a `jit_new_node_*` call.
-#[cfg(test)]
+macro_rules! private_make_func {
+    {
+        func = [{ $fname:ident $( < $( $life:lifetime ),+ > )? }]
+        body = [{ $( $body:tt )* }]
+        rettype = [{ $rettype:ty }]
+        parmhead = [{ $( $parmhead:tt )* }]
+        zipped = [{ $( $params:tt )* }]
+    } => {
+        pub fn $fname $( < $( $life ),+ > )? ( $( $parmhead )* $( $params )* ) -> $rettype {
+            $( $body )*
+        }
+    };
+}
+
+macro_rules! mm {
+    ( ( $entry:ident ( $( $inarg:ident ),* ) $root:ident ) => ( $( $types:ty ),* ) => ( $( $outarg:ident ),* ) ) => {
+        make_func! {
+            func = [{ $root }]
+            body = [{
+                unsafe {
+                    self.$entry( $( $inarg.to_ffi().into() ),* )
+                }
+            }]
+            rettype = [{ JitNode<'j> }]
+            parmhead = [{ &mut self, }]
+            parmnames = [{ $( $inarg ),* }]
+            parmtypes = [{ $( $types ),* }]
+        }
+    };
+}
+
+/// Infer immediate type
+macro_rules! it {
+    ( _d ) => { f64 };
+    ( _f ) => { f32 };
+    (    ) => { JitWord };
+}
+
+macro_rules! jit_inner {
+    // Ignores (by name) ---------------------------------------------------------------------------------------
+    // Bottom-level new-node
+    ( $a:tt [ new_node $(, $y:tt)* ] => $n:tt            $r:tt ) => { /* not part of the public interface */  };
+    // Internal movs
+    ( $a:tt [ mov, i, $k:tt, $w:tt ] => $n:tt            $r:tt ) => { /* not part of the public interface */  };
+    ( $a:tt [ mov, r, $k:tt, $w:tt ] => $n:tt            $r:tt ) => { /* not part of the public interface */  };
+
+    // Handlers (by name) --------------------------------------------------------------------------------------
+    // Immediate calls and jumps
+    ( $a:tt [ call, i              ] => $n:tt            $r:tt ) => { mm!{ $a => (JitPointer)         => $r } };
+    ( $a:tt [ jmp, i               ] => $n:tt            $r:tt ) => { mm!{ $a => ()                   => $r } };
+    // All ldi, sti, stxi (ldxi is handled by the jit_new_node_www catch-all)
+    ( $a:tt [ ld, i    $(, $y:tt)? ] => $n:tt            $r:tt ) => { mm!{ $a => (Reg, JitPointer)    => $r } };
+    ( $a:tt [ st, i    $(, $y:tt)? ] => $n:tt            $r:tt ) => { mm!{ $a => (JitPointer, Reg)    => $r } };
+    ( $a:tt [ stx, i   $(, $y:tt)? ] => $n:tt            $r:tt ) => { mm!{ $a => (JitWord, Reg, Reg)  => $r } };
+    // Movs
+    ( $a:tt [ mov, i   $(, $y:tt)? ] => $n:tt            $r:tt ) => { mm!{ $a => (Reg, it!{$($y)?})   => $r } };
+    // Varargs
+    ( $a:tt [ va_arg $(, _d)?      ] => $n:tt            $r:tt ) => { mm!{ $a => (Reg, Reg)           => $r } };
+
+    // Catch-alls (by signature) -------------------------------------------------------------------------------
+    // All quad instructions
+    ( $a:tt [ $q:tt, i $(, $y:tt)* ] => jit_new_node_qww $r:tt ) => { mm!{ $a => (i32, i32, Reg, Reg) => $r } };
+    ( $a:tt [ $q:tt, r $(, $y:tt)* ] => jit_new_node_qww $r:tt ) => { mm!{ $a => (Reg, Reg, Reg, Reg) => $r } };
+    // Branches
+    ( $a:tt [ $q:tt    $(, $y:tt)* ] => jit_new_node_pwd $r:tt ) => { mm!{ $a => (Reg, f64)           => $r } };
+    ( $a:tt [ $q:tt    $(, $y:tt)* ] => jit_new_node_pwf $r:tt ) => { mm!{ $a => (Reg, f32)           => $r } };
+    ( $a:tt [ $q:tt, r $(, $y:tt)* ] => jit_new_node_pww $r:tt ) => { mm!{ $a => (Reg, Reg)           => $r } };
+    ( $a:tt [ $q:tt, i $(, $y:tt)* ] => jit_new_node_pww $r:tt ) => { mm!{ $a => (Reg, JitWord)       => $r } };
+    // All jit_new_node_ww[fd]
+    ( $a:tt [ $q:tt, i, _d         ] => jit_new_node_wwd $r:tt ) => { mm!{ $a => (Reg, Reg, f64)      => $r } };
+    ( $a:tt [ $q:tt, i, _f         ] => jit_new_node_wwf $r:tt ) => { mm!{ $a => (Reg, Reg, f32)      => $r } };
+    // All jit_new_node_w+
+    ( $a:tt [ $q:tt, r             ] => jit_new_node_w   $r:tt ) => { mm!{ $a => (Reg)                => $r } };
+    ( $a:tt [ $q:tt                ] => jit_new_node_w   $r:tt ) => { mm!{ $a => (JitWord)            => $r } };
+    ( $a:tt [ $q:tt, r $(, $y:tt)* ] => jit_new_node_ww  $r:tt ) => { mm!{ $a => (Reg, Reg)           => $r } };
+    ( $a:tt [ $q:tt, i $(, $y:tt)? ] => jit_new_node_www $r:tt ) => { mm!{ $a => (Reg, Reg, JitWord)  => $r } };
+    ( $a:tt [ $q:tt, r $(, $y:tt)? ] => jit_new_node_www $r:tt ) => { mm!{ $a => (Reg, Reg, Reg)      => $r } };
+
+    // Fallbacks (generic patterns) ----------------------------------------------------------------------------
+    (   ( $entry:ident ( $( $inarg:ident ),* ) $root:ident )
+          [ $stem:ident $( , $suffix:ident )* ]
+          => $invokes:ident( $enum:ident $( , $outarg:ident )* )
+    ) => {
+        // Ensure all patterns are caught explicitly before this
+        compile_error!{ "Unhandled jit_entry -- jit_inner needs to be updated with a new pattern" }
+    };
+
+    ( $( $any:tt )* ) => { compile_error!{ "Unrecognized jit_entry -- check formatting of generated macros" } };
+}
+
+/// Defines an inherent method for `JitState` for each `jit_entry` that
+/// corresponds to a `jit_new_node_*` call.
+macro_rules! jit_entry_for_node {
+    {
+        $caller:tt
+        decl = [{ $entry:ident $inargs:tt }]
+        root = [{ $root:ident }]
+        parts = [{ $( $parts:ident )* }]
+        invokes = [{ $invokes:ident $outargs:tt }]
+    } => {
+        jit_inner!{
+            ( $entry $inargs $root )
+              [ $( $parts ),* ]
+              => $invokes $outargs
+        }
+    };
+}
+
+include!(concat!(env!("OUT_DIR"), "/entries.rs"));
+
 #[test]
 fn trivial_invocation() {
-    use tt_call::*;
-
     let mut entry_count = 0;
 
     trait MyDefault { fn default() -> Self; }

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -423,6 +423,28 @@ macro_rules! jit_entry_for_node {
     };
 }
 
+macro_rules! jit_entry_non_node {
+    {
+        $caller:tt
+        decl = [{ $entry:ident( $( $inarg:ident ),* ) }]
+        root = [{ destroy_state }]
+        parts = [{ $stem:ident $( $suffix:ident )* }]
+        invokes = [{ $invokes:ident( $( $outarg:ident ),* ) }]
+    } => {
+        make_func! {
+            func = [{ $stem }]
+            body = [{ unsafe { self.$entry( $( $inarg ),* ) } }]
+            rettype = [{ () }]
+            parmhead = [{ self, }] // Takes `self` by move, NOT by reference
+            parmnames = [{ }]
+            parmtypes = [{ }]
+        }
+    };
+    { $( $tokens:tt )* } => {
+        // Ignore these for now.
+    };
+}
+
 include!(concat!(env!("OUT_DIR"), "/entries.rs"));
 
 #[test]
@@ -467,16 +489,6 @@ fn trivial_invocation() {
     }
 
     macro_rules! jit_entry_non_node {
-        {
-            $caller:tt
-            decl = [{ $entry:ident( $( $inarg:ident ),* ) }]
-            root = [{ destroy_state }]
-            parts = [{ $stem:ident $( $suffix:ident )* }]
-            invokes = [{ $( $other:tt )* }]
-        } => {
-            // Ignore jit_destroy_state, since it gets turned into a Drop
-            // implementation and destroying before Drop seems problematic.
-        };
         {
             $caller:tt
             decl = [{ $entry:ident( $( $inarg:ident ),* ) }]

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -115,7 +115,7 @@ impl<'a> JitState<'a> {
     jit_reexport!(_jit_print, print);
 }
 
-/// implementations of word-size-dependent aliases
+/// implementations of word-size-dependent aliases and exports
 impl<'a> JitState<'a> {
     #[cfg(target_pointer_width = "64")]
     jit_alias!(getarg_l => getarg, reg: Reg, node: &JitNode<'a>);
@@ -172,6 +172,15 @@ impl<'a> JitState<'a> {
     jit_alias!(truncr_d_i => truncr_d, int: Reg, float: Reg; -> JitNode<'a>);
     #[cfg(target_pointer_width = "64")]
     jit_alias!(truncr_d_l => truncr_d, int: Reg, float: Reg; -> JitNode<'a>);
+
+    #[cfg(target_pointer_width = "64")]
+    jit_reexport!(_jit_getarg_ui, getarg_ui, reg: Reg, node: &JitNode<'a>);
+    #[cfg(target_pointer_width = "64")]
+    jit_reexport!(_jit_getarg_l, getarg_l, reg: Reg, node: &JitNode<'a>);
+    #[cfg(target_pointer_width = "64")]
+    jit_reexport!(_jit_retval_ui, retval_ui, rv: Reg);
+    #[cfg(target_pointer_width = "64")]
+    jit_reexport!(_jit_retval_l, retval_l, rv: Reg);
 }
 
 /// implementations of general instructions
@@ -221,10 +230,6 @@ impl<'a> JitState<'a> {
     jit_reexport!(_jit_getarg_s, getarg_s, reg: Reg, node: &JitNode<'a>);
     jit_reexport!(_jit_getarg_us, getarg_us, reg: Reg, node: &JitNode<'a>);
     jit_reexport!(_jit_getarg_i, getarg_i, reg: Reg, node: &JitNode<'a>);
-    #[cfg(target_pointer_width = "64")]
-    jit_reexport!(_jit_getarg_ui, getarg_ui, reg: Reg, node: &JitNode<'a>);
-    #[cfg(target_pointer_width = "64")]
-    jit_reexport!(_jit_getarg_l, getarg_l, reg: Reg, node: &JitNode<'a>);
 
     jit_reexport!(_jit_putargr, putargr, reg: Reg, arg: &JitNode<'a>);
     jit_reexport!(_jit_putargi, putargi, imm: JitWord, arg: &JitNode<'a>);
@@ -266,10 +271,6 @@ impl<'a> JitState<'a> {
     jit_reexport!(_jit_retval_s, retval_s, rv: Reg);
     jit_reexport!(_jit_retval_us, retval_us, rv: Reg);
     jit_reexport!(_jit_retval_i, retval_i, rv: Reg);
-    #[cfg(target_pointer_width = "64")]
-    jit_reexport!(_jit_retval_ui, retval_ui, rv: Reg);
-    #[cfg(target_pointer_width = "64")]
-    jit_reexport!(_jit_retval_l, retval_l, rv: Reg);
     jit_reexport!(_jit_epilog, epilog);
 
     jit_reexport!(_jit_frame, frame, size: i32);

--- a/src/jitstate.rs
+++ b/src/jitstate.rs
@@ -92,7 +92,7 @@ impl<'a> JitState<'a> {
         unsafe { bindings::_jit_get_code(self.state, pointer_from(code_size)) }
     }
 
-    jit_reexport!(_jit_set_code, set_code, buf: JitPointer, size: JitWord; -> ());
+    jit_reexport!(_jit_set_code, set_code, buf: JitPointer, size: JitWord);
 
     // get_data needs argument mangling that jit_reexport currently does not
     // provide
@@ -110,7 +110,7 @@ impl<'a> JitState<'a> {
         }
     }
 
-    jit_reexport!(_jit_set_data, set_data, buf: JitPointer, data_size: JitWord, flags: JitWord; -> ());
+    jit_reexport!(_jit_set_data, set_data, buf: JitPointer, data_size: JitWord, flags: JitWord);
 
     jit_reexport!(_jit_print, print);
 }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -289,6 +289,22 @@ macro_rules! jit_entry_for_node {
 }
 
 macro_rules! jit_entry_non_node {
+    {
+        $caller:tt
+        decl = [{ $entry:ident( $( $inarg:ident ),* ) }]
+        root = [{ destroy_state }]
+        parts = [{ $stem:ident $( $suffix:ident )* }]
+        invokes = [{ $invokes:ident( _jit $( , $outarg:ident )* ) }]
+    } => {
+        make_func! {
+            func = [{ $entry }]
+            body = [{ $invokes( self.state, $( $outarg ),* ) }]
+            rettype = [{ () }]
+            parmhead = [{ self, }] // Takes `self` by move, NOT by reference
+            parmnames = [{ }]
+            parmtypes = [{ }]
+        }
+    };
     { $( $tokens:tt )* } => {
         // Ignore these for now.
     };
@@ -407,6 +423,12 @@ fn trivial_invocation() {
                 $( let $inarg = MyDefault::default(); )*
                 let _ = $crate::Jit::new().new_state().$entry( $( $inarg ),* );
             }
+        };
+    }
+
+    macro_rules! jit_entry_non_node {
+        { $( $tokens:tt )* } => {
+            // Ignore these for now.
         };
     }
 


### PR DESCRIPTION
This PR completes the refactoring of the PR originally introduced as #43. It uses the mechanization from #32 and macros introduced in #54, along with a new pattern-matching methodology, to generate entry points via a pattern-matching scheme.

One theoretical advantage of this approach is that it *could* allow automatic support of minor changes to the GNU lightning API as long as they are consistent within the implied rules of the pattern matching. This is not really a major concern since GNU lightning does not have frequent releases.

Another theoretical advantage is that it could ease special treatment of subsets of entry points, rather than treating every entry point individually. This may or may not be useful.

The main advantage of doing things this way is that it is what allowed the discovery of missing entry points (fixed in #34, #35, #37, #42). However, since all entry points are checked for existence now via #54, the current PR does not technically make it any easier to find missing entry points.